### PR TITLE
fix: implement atomic file writes in SaveToFile

### DIFF
--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -57,15 +58,42 @@ func Load(path string) (*XCStrings, error) {
 	return &xcstrings, nil
 }
 
-// SaveToFile writes the XCStrings data to a file at the given path.
+// SaveToFile writes the XCStrings data to a file at the given path using atomic writes.
+// It writes to a temporary file in the same directory, syncs to disk, then renames
+// to the target path to prevent data corruption from interrupted writes.
 func (x *XCStrings) SaveToFile(path string) error {
 	data, err := json.MarshalIndent(x, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".xcstrings-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Clean up temp file on error; after successful rename this is a no-op.
+		os.Remove(tmpPath)
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to sync temp file: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 
 	return nil

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -475,6 +475,105 @@ func TestXCStrings_LoadEmptyLocalizationsInitialized(t *testing.T) {
 	test.AssertEqual(t, len(reloadedFormatKey.Localizations), 0)
 }
 
+func TestXCStrings_SaveToFile_AtomicWrite(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"key": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Value"}},
+				},
+			},
+		},
+		Version: "1.0",
+	}
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "atomic.xcstrings")
+
+	err := xcstrings.SaveToFile(filePath)
+	test.AssertNoError(t, err)
+
+	// Verify no temp files remain in the directory
+	entries, err := os.ReadDir(tmpDir)
+	test.AssertNoError(t, err)
+
+	if len(entries) != 1 {
+		t.Errorf("expected exactly 1 file in dir, got %d", len(entries))
+	}
+	if entries[0].Name() != "atomic.xcstrings" {
+		t.Errorf("expected file name atomic.xcstrings, got %s", entries[0].Name())
+	}
+
+	// Verify file content is correct after atomic write
+	loaded, err := Load(filePath)
+	test.AssertNoError(t, err)
+	test.AssertEqual(t, loaded.SourceLanguage, "en")
+	test.AssertEqual(t, loaded.Version, "1.0")
+	test.AssertEqual(t, len(loaded.Strings), 1)
+}
+
+func TestXCStrings_SaveToFile_InvalidDirectory(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings:        map[string]StringDefinition{},
+		Version:        "1.0",
+	}
+
+	err := xcstrings.SaveToFile("/nonexistent/directory/file.xcstrings")
+	test.AssertError(t, err)
+}
+
+func TestXCStrings_SaveToFile_OverwriteExisting(t *testing.T) {
+	original := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"old_key": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Old"}},
+				},
+			},
+		},
+		Version: "1.0",
+	}
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "overwrite.xcstrings")
+
+	err := original.SaveToFile(filePath)
+	test.AssertNoError(t, err)
+
+	// Overwrite with new content
+	updated := &XCStrings{
+		SourceLanguage: "ja",
+		Strings: map[string]StringDefinition{
+			"new_key": {
+				Localizations: map[string]Localization{
+					"ja": {StringUnit: StringUnit{State: "translated", Value: "New"}},
+				},
+			},
+		},
+		Version: "2.0",
+	}
+
+	err = updated.SaveToFile(filePath)
+	test.AssertNoError(t, err)
+
+	// Verify overwritten content
+	loaded, err := Load(filePath)
+	test.AssertNoError(t, err)
+	test.AssertEqual(t, loaded.SourceLanguage, "ja")
+	test.AssertEqual(t, loaded.Version, "2.0")
+	test.AssertEqual(t, len(loaded.Strings), 1)
+
+	// Verify no temp files remain
+	entries, err := os.ReadDir(tmpDir)
+	test.AssertNoError(t, err)
+	if len(entries) != 1 {
+		t.Errorf("expected exactly 1 file after overwrite, got %d", len(entries))
+	}
+}
+
 func TestXCStrings_GetTranslatedKeys(t *testing.T) {
 	xcstrings := &XCStrings{
 		SourceLanguage: "en",


### PR DESCRIPTION
## Summary
- Replace `os.WriteFile` with atomic write pattern (temp file → fsync → rename)
- Prevents .xcstrings file corruption if process is interrupted mid-write

## Test plan
- [x] Existing tests pass
- [x] New test: atomic write leaves no temp files
- [x] New test: error on invalid directory
- [x] New test: atomic overwrite of existing file

Closes #16