### PR TITLE
fix: prevent SetTranslation from overwriting existing localization data

### DIFF
--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -124,12 +124,12 @@ func (x *XCStrings) SetTranslation(key, language, value string) error {
 		definition.Localizations = make(map[string]Localization)
 	}
 
-	definition.Localizations[language] = Localization{
-		StringUnit: StringUnit{
-			State: "translated",
-			Value: value,
-		},
+	loc := definition.Localizations[language]
+	loc.StringUnit = StringUnit{
+		State: "translated",
+		Value: value,
 	}
+	definition.Localizations[language] = loc
 
 	x.Strings[key] = definition
 	return nil

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -327,6 +327,40 @@ func TestXCStrings_SetTranslation(t *testing.T) {
 	}
 }
 
+func TestXCStrings_SetTranslation_PreservesExistingLocalization(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"greeting": {
+				Comment:         "A greeting message",
+				ExtractionState: "manual",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Hello"}},
+					"ja": {StringUnit: StringUnit{State: "translated", Value: "こんにちは"}},
+				},
+			},
+		},
+	}
+
+	// Update the Japanese translation
+	err := xcstrings.SetTranslation("greeting", "ja", "やあ")
+	test.AssertNoError(t, err)
+
+	// Verify the translation was updated
+	loc := xcstrings.Strings["greeting"].Localizations["ja"]
+	test.AssertEqual(t, loc.StringUnit.State, "translated")
+	test.AssertEqual(t, loc.StringUnit.Value, "やあ")
+
+	// Verify other localizations are not affected
+	enLoc := xcstrings.Strings["greeting"].Localizations["en"]
+	test.AssertEqual(t, enLoc.StringUnit.Value, "Hello")
+
+	// Verify StringDefinition-level fields are preserved
+	def := xcstrings.Strings["greeting"]
+	test.AssertEqual(t, def.Comment, "A greeting message")
+	test.AssertEqual(t, def.ExtractionState, "manual")
+}
+
 func TestFilterKeysByPrefix(t *testing.T) {
 	xcstrings := &XCStrings{}
 


### PR DESCRIPTION
## Summary
- Fix SetTranslation to update StringUnit in-place rather than replacing entire Localization
- Prevents silent data loss when Localization gains additional fields

## Test plan
- [x] Existing tests pass
- [x] New test: existing fields preserved after SetTranslation

Closes #17