### PR TITLE
feat: support needs_review state

### DIFF
--- a/command/status.go
+++ b/command/status.go
@@ -51,10 +51,11 @@ func (c *StatusCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 
 	for _, lang := range languages {
 		untranslated := xcstrings.UntranslatedKeys(lang)
+		needsReview := xcstrings.NeedsReviewKeys(lang)
 		translated := totalKeys - len(untranslated)
 		percentage := float64(translated) / float64(totalKeys) * 100
 
-		fmt.Printf("%-6s: %3d/%d translated (%.1f%%)\n", lang, translated, totalKeys, percentage)
+		fmt.Printf("%-6s: %3d/%d translated, %d needs_review (%.1f%%)\n", lang, translated, totalKeys, len(needsReview), percentage)
 	}
 
 	return subcommands.ExitSuccess

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -50,6 +50,59 @@ func TestStatusCommand_Execute(t *testing.T) {
 		"Languages:",
 		"en",
 		"ja",
+		"needs_review",
+	}
+
+	for _, expected := range expectedContent {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output should contain %q, got: %q", expected, output)
+		}
+	}
+}
+
+func TestStatusCommand_Execute_WithNeedsReview(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"key1": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Key 1"}},
+					"ja": {"stringUnit": {"state": "translated", "value": "キー1"}}
+				}
+			},
+			"key2": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Key 2"}},
+					"ja": {"stringUnit": {"state": "needs_review", "value": "キー2"}}
+				}
+			},
+			"key3": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Key 3"}},
+					"ja": {"stringUnit": {"state": "new", "value": ""}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &StatusCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	expectedContent := []string{
+		"Total Keys: 3",
+		"1 needs_review",
 	}
 
 	for _, expected := range expectedContent {

--- a/fixtures/needs_review.xcstrings
+++ b/fixtures/needs_review.xcstrings
@@ -1,0 +1,41 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "translated_key": {
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Translated"}},
+        "ja": {"stringUnit": {"state": "translated", "value": "翻訳済み"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Traducido"}}
+      }
+    },
+    "needs_review_key": {
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Needs Review"}},
+        "ja": {"stringUnit": {"state": "needs_review", "value": "レビュー必要"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Necesita revisión"}}
+      }
+    },
+    "untranslated_key": {
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Untranslated"}},
+        "ja": {"stringUnit": {"state": "new", "value": ""}},
+        "es": {"stringUnit": {"state": "new", "value": ""}}
+      }
+    },
+    "multiple_needs_review": {
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Multiple Reviews"}},
+        "ja": {"stringUnit": {"state": "needs_review", "value": "レビュー必要2"}},
+        "es": {"stringUnit": {"state": "needs_review", "value": "Necesita revisión 2"}}
+      }
+    },
+    "do_not_translate": {
+      "shouldTranslate": false,
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Do Not Translate"}},
+        "ja": {"stringUnit": {"state": "needs_review", "value": "翻訳不要"}}
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -160,6 +160,21 @@ func (x *XCStrings) KeysWithAnyUntranslated() []string {
 	return result
 }
 
+// NeedsReviewKeys returns keys that have needs_review state for the given language.
+func (x *XCStrings) NeedsReviewKeys(language string) []string {
+	var keys []string
+	for key, def := range x.Strings {
+		if def.ShouldTranslate != nil && !*def.ShouldTranslate {
+			continue
+		}
+		loc, exists := def.Localizations[language]
+		if exists && loc.StringUnit.State == "needs_review" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
 // TranslatedKeys returns keys that are translated for the given language.
 func (x *XCStrings) TranslatedKeys(language string) []string {
 	var translated []string

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -475,6 +475,82 @@ func TestXCStrings_LoadEmptyLocalizationsInitialized(t *testing.T) {
 	test.AssertEqual(t, len(reloadedFormatKey.Localizations), 0)
 }
 
+func TestXCStrings_NeedsReviewKeys(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"translated_key": {
+				Localizations: map[string]Localization{
+					"ja": {StringUnit: StringUnit{State: "translated", Value: "翻訳済み"}},
+				},
+			},
+			"needs_review_key": {
+				Localizations: map[string]Localization{
+					"ja": {StringUnit: StringUnit{State: "needs_review", Value: "レビュー必要"}},
+				},
+			},
+			"untranslated_key": {
+				Localizations: map[string]Localization{
+					"ja": {StringUnit: StringUnit{State: "new", Value: ""}},
+				},
+			},
+			"missing_key": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Missing"}},
+				},
+			},
+			"should_not_translate": {
+				ShouldTranslate: func() *bool { b := false; return &b }(),
+				Localizations: map[string]Localization{
+					"ja": {StringUnit: StringUnit{State: "needs_review", Value: "翻訳不要"}},
+				},
+			},
+		},
+	}
+
+	t.Run("returns only needs_review keys", func(t *testing.T) {
+		got := xcstrings.NeedsReviewKeys("ja")
+		want := []string{"needs_review_key"}
+
+		sort.Strings(got)
+		sort.Strings(want)
+		test.AssertSliceEqual(t, got, want)
+	})
+
+	t.Run("needs_review keys are included in untranslated", func(t *testing.T) {
+		untranslated := xcstrings.UntranslatedKeys("ja")
+		sort.Strings(untranslated)
+
+		// needs_review_key should be in untranslated since state != "translated"
+		found := false
+		for _, key := range untranslated {
+			if key == "needs_review_key" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected needs_review_key to appear in UntranslatedKeys result")
+		}
+	})
+
+	t.Run("no needs_review keys for language without any", func(t *testing.T) {
+		got := xcstrings.NeedsReviewKeys("fr")
+		if len(got) != 0 {
+			t.Errorf("expected 0 needs_review keys for fr, got %d", len(got))
+		}
+	})
+
+	t.Run("skips shouldTranslate=false", func(t *testing.T) {
+		got := xcstrings.NeedsReviewKeys("ja")
+		for _, key := range got {
+			if key == "should_not_translate" {
+				t.Error("should_not_translate key should be excluded from NeedsReviewKeys")
+			}
+		}
+	})
+}
+
 func TestXCStrings_GetTranslatedKeys(t *testing.T) {
 	xcstrings := &XCStrings{
 		SourceLanguage: "en",


### PR DESCRIPTION
## Summary
- Add NeedsReviewKeys() method to identify keys with needs_review state
- Update status command to report needs_review count separately
- needs_review keys continue to appear in untranslated results (state \!= translated)

## Test plan
- [x] All existing tests pass
- [x] New test: NeedsReviewKeys returns correct keys
- [x] New test: status output includes needs_review count
- [x] New fixture with needs_review state entries

Closes #21