### PR TITLE
feat: support stale state

### DIFF
--- a/command/stale.go
+++ b/command/stale.go
@@ -1,0 +1,79 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+
+	"github.com/google/subcommands"
+)
+
+type StaleCommand struct {
+	XCStringsCommand
+	remove bool
+	dryRun bool
+}
+
+func (*StaleCommand) Name() string {
+	return "stale"
+}
+
+func (*StaleCommand) Synopsis() string {
+	return "List or remove stale keys"
+}
+
+func (*StaleCommand) Usage() string {
+	return "stale [-f file.xcstrings] [--remove] [--dry-run]: List or remove stale keys\n"
+}
+
+func (c *StaleCommand) SetFlags(f *flag.FlagSet) {
+	c.SetXCStringsFlags(f)
+	f.BoolVar(&c.remove, "remove", false, "Remove stale keys from the file")
+	f.BoolVar(&c.dryRun, "dry-run", false, "Preview removal without writing changes")
+}
+
+func (c *StaleCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	xcstrings, err := c.LoadXCStrings()
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	staleKeys := xcstrings.StaleKeys()
+	sort.Strings(staleKeys)
+
+	if len(staleKeys) == 0 {
+		fmt.Println("No stale keys found")
+		return subcommands.ExitSuccess
+	}
+
+	if c.remove {
+		if c.dryRun {
+			fmt.Printf("Would remove %d stale key(s):\n", len(staleKeys))
+			for _, key := range staleKeys {
+				fmt.Printf("  - %s\n", key)
+			}
+			return subcommands.ExitSuccess
+		}
+
+		for _, key := range staleKeys {
+			delete(xcstrings.Strings, key)
+		}
+
+		if err := xcstrings.SaveToFile(c.filePath); err != nil {
+			fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+			return subcommands.ExitFailure
+		}
+
+		fmt.Printf("Removed %d stale key(s)\n", len(staleKeys))
+		return subcommands.ExitSuccess
+	}
+
+	fmt.Printf("Stale keys (%d):\n", len(staleKeys))
+	for _, key := range staleKeys {
+		fmt.Printf("  - %s\n", key)
+	}
+
+	return subcommands.ExitSuccess
+}

--- a/command/stale_test.go
+++ b/command/stale_test.go
@@ -1,0 +1,184 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"xckit/helper/test"
+	"xckit/xcstrings"
+)
+
+func TestStaleCommand_Execute(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedStatus int
+		shouldContain  []string
+	}{
+		{
+			name:           "list stale keys",
+			args:           []string{},
+			expectedStatus: 0,
+			shouldContain:  []string{"stale_key", "another_stale_key", "Stale keys (2)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixturePath := filepath.Join("../fixtures", "stale.xcstrings")
+
+			cmd := &StaleCommand{}
+			flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+			cmd.SetFlags(flagSet)
+
+			args := append([]string{"-f", fixturePath}, tt.args...)
+			err := flagSet.Parse(args)
+			test.AssertNoError(t, err)
+
+			output := captureOutput(func() {
+				status := cmd.Execute(context.Background(), flagSet)
+				test.AssertEqual(t, int(status), tt.expectedStatus)
+			})
+
+			for _, expected := range tt.shouldContain {
+				if !strings.Contains(output, expected) {
+					t.Errorf("output should contain %q, got: %q", expected, output)
+				}
+			}
+		})
+	}
+}
+
+func TestStaleCommand_Execute_NoStaleKeys(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"key1": {
+				"extractionState": "manual",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Key 1"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &StaleCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "No stale keys found") {
+		t.Errorf("output should contain 'No stale keys found', got: %q", output)
+	}
+}
+
+func TestStaleCommand_Execute_DryRun(t *testing.T) {
+	fixturePath := filepath.Join("../fixtures", "stale.xcstrings")
+
+	cmd := &StaleCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", fixturePath, "--remove", "--dry-run"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Would remove 2 stale key(s)") {
+		t.Errorf("output should contain dry-run message, got: %q", output)
+	}
+	if !strings.Contains(output, "stale_key") {
+		t.Errorf("output should contain 'stale_key', got: %q", output)
+	}
+	if !strings.Contains(output, "another_stale_key") {
+		t.Errorf("output should contain 'another_stale_key', got: %q", output)
+	}
+
+	// Verify the fixture was not modified by loading it again
+	loaded, err := xcstrings.Load(fixturePath)
+	test.AssertNoError(t, err)
+	test.AssertEqual(t, len(loaded.StaleKeys()), 2)
+}
+
+func TestStaleCommand_Execute_Remove(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"active_key": {
+				"extractionState": "manual",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Active"}}
+				}
+			},
+			"stale_key": {
+				"extractionState": "stale",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Stale"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &StaleCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--remove"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Removed 1 stale key(s)") {
+		t.Errorf("output should contain removal message, got: %q", output)
+	}
+
+	// Verify the file was modified
+	loaded, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	test.AssertEqual(t, len(loaded.Strings), 1)
+	test.AssertEqual(t, len(loaded.StaleKeys()), 0)
+}
+
+func TestStaleCommand_Execute_FileNotFound(t *testing.T) {
+	cmd := &StaleCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(&strings.Builder{})
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", "nonexistent.xcstrings"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 1)
+}
+
+func TestStaleCommand_Metadata(t *testing.T) {
+	cmd := &StaleCommand{}
+
+	test.AssertEqual(t, cmd.Name(), "stale")
+	test.AssertEqual(t, cmd.Synopsis(), "List or remove stale keys")
+
+	usage := cmd.Usage()
+	if !strings.Contains(usage, "stale") {
+		t.Errorf("usage should contain 'stale', got: %q", usage)
+	}
+}

--- a/command/status.go
+++ b/command/status.go
@@ -37,6 +37,8 @@ func (c *StatusCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	}
 
 	totalKeys := len(xcstrings.Strings)
+	staleKeys := len(xcstrings.StaleKeys())
+	activeKeys := totalKeys - staleKeys
 	languages := xcstrings.Languages()
 	sort.Strings(languages)
 
@@ -44,6 +46,8 @@ func (c *StatusCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	fmt.Printf("==================\n")
 	fmt.Printf("Source Language: %s\n", xcstrings.SourceLanguage)
 	fmt.Printf("Total Keys: %d\n", totalKeys)
+	fmt.Printf("Stale Keys: %d\n", staleKeys)
+	fmt.Printf("Active Keys: %d\n", activeKeys)
 	fmt.Printf("Languages: %s\n\n", languages)
 
 	fmt.Printf("Progress by Language:\n")
@@ -51,10 +55,13 @@ func (c *StatusCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 
 	for _, lang := range languages {
 		untranslated := xcstrings.UntranslatedKeys(lang)
-		translated := totalKeys - len(untranslated)
-		percentage := float64(translated) / float64(totalKeys) * 100
+		translated := activeKeys - len(untranslated)
+		var percentage float64
+		if activeKeys > 0 {
+			percentage = float64(translated) / float64(activeKeys) * 100
+		}
 
-		fmt.Printf("%-6s: %3d/%d translated (%.1f%%)\n", lang, translated, totalKeys, percentage)
+		fmt.Printf("%-6s: %3d/%d translated (%.1f%%)\n", lang, translated, activeKeys, percentage)
 	}
 
 	return subcommands.ExitSuccess

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -47,6 +47,8 @@ func TestStatusCommand_Execute(t *testing.T) {
 		"Translation Status",
 		"Source Language: en",
 		"Total Keys: 2",
+		"Stale Keys: 0",
+		"Active Keys: 2",
 		"Languages:",
 		"en",
 		"ja",
@@ -56,6 +58,66 @@ func TestStatusCommand_Execute(t *testing.T) {
 		if !strings.Contains(output, expected) {
 			t.Errorf("output should contain %q, got: %q", expected, output)
 		}
+	}
+}
+
+func TestStatusCommand_Execute_WithStaleKeys(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"active_key": {
+				"extractionState": "manual",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Active"}},
+					"ja": {"stringUnit": {"state": "translated", "value": "アクティブ"}}
+				}
+			},
+			"stale_key": {
+				"extractionState": "stale",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Stale"}},
+					"ja": {"stringUnit": {"state": "translated", "value": "古い"}}
+				}
+			},
+			"untranslated_key": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Untranslated"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &StatusCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	expectedContent := []string{
+		"Total Keys: 3",
+		"Stale Keys: 1",
+		"Active Keys: 2",
+	}
+
+	for _, expected := range expectedContent {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output should contain %q, got: %q", expected, output)
+		}
+	}
+
+	// Progress should be based on active keys (2), not total keys (3)
+	// ja: 1 translated out of 2 active = 50.0%
+	if !strings.Contains(output, "1/2 translated (50.0%)") {
+		t.Errorf("output should show progress based on active keys, got: %q", output)
 	}
 }
 

--- a/fixtures/stale.xcstrings
+++ b/fixtures/stale.xcstrings
@@ -1,0 +1,62 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "active_key": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティブ"
+          }
+        }
+      }
+    },
+    "stale_key": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古い"
+          }
+        }
+      }
+    },
+    "another_stale_key": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Another Stale"
+          }
+        }
+      }
+    },
+    "untranslated_active": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untranslated Active"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/formatter/display.go
+++ b/formatter/display.go
@@ -12,8 +12,12 @@ func DisplayKeyDetails(x *xcstrings.XCStrings, keys []string) {
 	sort.Strings(languages)
 
 	for _, key := range keys {
-		fmt.Printf("\n%s:\n", key)
 		definition := x.Strings[key]
+		if definition.ExtractionState == "stale" {
+			fmt.Printf("\n%s [stale]:\n", key)
+		} else {
+			fmt.Printf("\n%s:\n", key)
+		}
 		for _, lang := range languages {
 			if localization, exists := definition.Localizations[lang]; exists {
 				state := localization.StringUnit.State

--- a/formatter/display_test.go
+++ b/formatter/display_test.go
@@ -165,6 +165,44 @@ func TestDisplayKeyDetails_OutputFormat(t *testing.T) {
 	}
 }
 
+func TestDisplayKeyDetails_StaleMarker(t *testing.T) {
+	xcstringsData := &xcstrings.XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]xcstrings.StringDefinition{
+			"stale_key": {
+				ExtractionState: "stale",
+				Localizations: map[string]xcstrings.Localization{
+					"en": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "Stale"}},
+					"ja": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "古い"}},
+				},
+			},
+			"active_key": {
+				ExtractionState: "manual",
+				Localizations: map[string]xcstrings.Localization{
+					"en": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "Active"}},
+					"ja": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "アクティブ"}},
+				},
+			},
+		},
+	}
+
+	output := captureOutput(func() {
+		DisplayKeyDetails(xcstringsData, []string{"stale_key", "active_key"})
+	})
+
+	if !strings.Contains(output, "stale_key [stale]:") {
+		t.Errorf("output should contain 'stale_key [stale]:', got:\n%s", output)
+	}
+
+	// active_key should NOT have [stale] marker
+	if strings.Contains(output, "active_key [stale]") {
+		t.Errorf("output should not contain 'active_key [stale]', got:\n%s", output)
+	}
+	if !strings.Contains(output, "active_key:") {
+		t.Errorf("output should contain 'active_key:', got:\n%s", output)
+	}
+}
+
 func TestDisplayKeyDetails_LanguageSorting(t *testing.T) {
 	xcstringsData := &xcstrings.XCStrings{
 		SourceLanguage: "en",

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ func main() {
 	subcommands.Register(&command.UntranslatedCommand{}, "")
 	subcommands.Register(&command.ListCommand{}, "")
 	subcommands.Register(&command.SetCommand{}, "")
+	subcommands.Register(&command.StaleCommand{}, "")
 	subcommands.Register(&command.StatusCommand{}, "")
 	subcommands.Register(&command.VersionCommand{}, "")
 	subcommands.Register(subcommands.HelpCommand(), "")

--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -109,9 +109,13 @@ func (x *XCStrings) Keys() []string {
 }
 
 // UntranslatedKeys returns keys that are not translated for the given language.
+// Stale keys are excluded from the result.
 func (x *XCStrings) UntranslatedKeys(language string) []string {
 	var untranslated []string
 	for key, definition := range x.Strings {
+		if definition.ExtractionState == "stale" {
+			continue
+		}
 		if definition.ShouldTranslate != nil && *definition.ShouldTranslate == false {
 			continue
 		}
@@ -164,11 +168,15 @@ func (x *XCStrings) SetTranslation(key, language, value string) error {
 }
 
 // KeysWithAnyUntranslated returns keys that have at least one untranslated language.
+// Stale keys are excluded from the result.
 func (x *XCStrings) KeysWithAnyUntranslated() []string {
 	var result []string
 	languages := x.Languages()
 
 	for key, definition := range x.Strings {
+		if definition.ExtractionState == "stale" {
+			continue
+		}
 		if definition.ShouldTranslate != nil && *definition.ShouldTranslate == false {
 			continue
 		}
@@ -186,6 +194,28 @@ func (x *XCStrings) KeysWithAnyUntranslated() []string {
 	}
 
 	return result
+}
+
+// StaleKeys returns keys that have extractionState "stale".
+func (x *XCStrings) StaleKeys() []string {
+	var keys []string
+	for key, def := range x.Strings {
+		if def.ExtractionState == "stale" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+// ActiveKeys returns keys that do not have extractionState "stale".
+func (x *XCStrings) ActiveKeys() []string {
+	var keys []string
+	for key, def := range x.Strings {
+		if def.ExtractionState != "stale" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
 }
 
 // TranslatedKeys returns keys that are translated for the given language.

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -608,6 +608,137 @@ func TestXCStrings_SaveToFile_OverwriteExisting(t *testing.T) {
 	}
 }
 
+func TestXCStrings_StaleKeys(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"active_key": {
+				ExtractionState: "manual",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
+				},
+			},
+			"stale_key": {
+				ExtractionState: "stale",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Stale"}},
+				},
+			},
+			"another_stale": {
+				ExtractionState: "stale",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Another Stale"}},
+				},
+			},
+			"no_state_key": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "No State"}},
+				},
+			},
+		},
+	}
+
+	got := xcstrings.StaleKeys()
+	sort.Strings(got)
+	want := []string{"another_stale", "stale_key"}
+	test.AssertSliceEqual(t, got, want)
+}
+
+func TestXCStrings_ActiveKeys(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"active_key": {
+				ExtractionState: "manual",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
+				},
+			},
+			"stale_key": {
+				ExtractionState: "stale",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Stale"}},
+				},
+			},
+			"no_state_key": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "No State"}},
+				},
+			},
+		},
+	}
+
+	got := xcstrings.ActiveKeys()
+	sort.Strings(got)
+	want := []string{"active_key", "no_state_key"}
+	test.AssertSliceEqual(t, got, want)
+}
+
+func TestXCStrings_UntranslatedKeys_ExcludesStale(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"active_untranslated": {
+				ExtractionState: "manual",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
+				},
+			},
+			"stale_untranslated": {
+				ExtractionState: "stale",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Stale"}},
+				},
+			},
+			"active_translated": {
+				ExtractionState: "manual",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
+					"ja": {StringUnit: StringUnit{State: "translated", Value: "翻訳済み"}},
+				},
+			},
+		},
+	}
+
+	got := xcstrings.UntranslatedKeys("ja")
+	sort.Strings(got)
+	want := []string{"active_untranslated"}
+	test.AssertSliceEqual(t, got, want)
+}
+
+func TestXCStrings_KeysWithAnyUntranslated_ExcludesStale(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"active_untranslated": {
+				ExtractionState: "manual",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
+					"ja": {StringUnit: StringUnit{State: "new", Value: ""}},
+				},
+			},
+			"stale_untranslated": {
+				ExtractionState: "stale",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Stale"}},
+					"ja": {StringUnit: StringUnit{State: "new", Value: ""}},
+				},
+			},
+			"active_translated": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
+					"ja": {StringUnit: StringUnit{State: "translated", Value: "翻訳済み"}},
+				},
+			},
+		},
+	}
+
+	got := xcstrings.KeysWithAnyUntranslated()
+	sort.Strings(got)
+	want := []string{"active_untranslated"}
+	test.AssertSliceEqual(t, got, want)
+}
+
 func TestXCStrings_GetTranslatedKeys(t *testing.T) {
 	xcstrings := &XCStrings{
 		SourceLanguage: "en",


### PR DESCRIPTION
## Summary
- Add StaleKeys() and ActiveKeys() methods
- UntranslatedKeys and KeysWithAnyUntranslated now exclude stale keys
- Status command reports stale keys separately and excludes from progress %
- List command shows [stale] marker
- Add stale subcommand with --remove and --dry-run support
- Add fixture with stale state entries

## Test plan
- [x] All existing tests pass
- [x] New tests for StaleKeys/ActiveKeys
- [x] New tests for stale exclusion in untranslated
- [x] New tests for stale subcommand

Closes #22