### PR TITLE
feat: add unified variation type definitions

### DIFF
--- a/fixtures/device_variations.xcstrings
+++ b/fixtures/device_variations.xcstrings
@@ -1,0 +1,34 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "welcome_message": {
+      "localizations": {
+        "en": {
+          "variations": {
+            "device": {
+              "iphone": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Welcome to our iPhone app"
+                }
+              },
+              "ipad": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Welcome to our iPad app"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Welcome to our app"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/fixtures/nested_variations.xcstrings
+++ b/fixtures/nested_variations.xcstrings
@@ -1,0 +1,52 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "photo_count": {
+      "localizations": {
+        "en": {
+          "variations": {
+            "device": {
+              "iphone": {
+                "variations": {
+                  "plural": {
+                    "one": {
+                      "stringUnit": {
+                        "state": "translated",
+                        "value": "%lld photo on your iPhone"
+                      }
+                    },
+                    "other": {
+                      "stringUnit": {
+                        "state": "translated",
+                        "value": "%lld photos on your iPhone"
+                      }
+                    }
+                  }
+                }
+              },
+              "other": {
+                "variations": {
+                  "plural": {
+                    "one": {
+                      "stringUnit": {
+                        "state": "translated",
+                        "value": "%lld photo on your device"
+                      }
+                    },
+                    "other": {
+                      "stringUnit": {
+                        "state": "translated",
+                        "value": "%lld photos on your device"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/fixtures/plural_variations.xcstrings
+++ b/fixtures/plural_variations.xcstrings
@@ -1,0 +1,40 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "item_count": {
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld item"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld items"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld個のアイテム"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/fixtures/substitutions.xcstrings
+++ b/fixtures/substitutions.xcstrings
@@ -1,0 +1,58 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "upload_progress": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uploading %#@file_count@ to %#@folder@"
+          },
+          "substitutions": {
+            "file_count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg file"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg files"
+                    }
+                  }
+                }
+              }
+            },
+            "folder": {
+              "argNum": 2,
+              "formatSpecifier": "@",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg folder"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg folders"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/formatter/display.go
+++ b/formatter/display.go
@@ -16,12 +16,16 @@ func DisplayKeyDetails(x *xcstrings.XCStrings, keys []string) {
 		definition := x.Strings[key]
 		for _, lang := range languages {
 			if localization, exists := definition.Localizations[lang]; exists {
-				state := localization.StringUnit.State
-				value := localization.StringUnit.Value
-				if value == "" {
-					value = "(empty)"
+				if localization.StringUnit != nil {
+					state := localization.StringUnit.State
+					value := localization.StringUnit.Value
+					if value == "" {
+						value = "(empty)"
+					}
+					fmt.Printf("  %s: %s - %s\n", lang, state, value)
+				} else {
+					fmt.Printf("  %s: (variations)\n", lang)
 				}
-				fmt.Printf("  %s: %s - %s\n", lang, state, value)
 			} else {
 				fmt.Printf("  %s: missing\n", lang)
 			}

--- a/formatter/display_test.go
+++ b/formatter/display_test.go
@@ -34,20 +34,20 @@ func TestDisplayKeyDetails(t *testing.T) {
 				Comment:         "A greeting",
 				ExtractionState: "manual",
 				Localizations: map[string]xcstrings.Localization{
-					"en": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "Hello"}},
-					"ja": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "こんにちは"}},
-					"es": {StringUnit: xcstrings.StringUnit{State: "new", Value: "Hola"}},
+					"en": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Hello"}},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "こんにちは"}},
+					"es": {StringUnit: &xcstrings.StringUnit{State: "new", Value: "Hola"}},
 				},
 			},
 			"goodbye": {
 				Localizations: map[string]xcstrings.Localization{
-					"en": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "Goodbye"}},
-					"ja": {StringUnit: xcstrings.StringUnit{State: "translated", Value: ""}}, // Empty value
+					"en": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Goodbye"}},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: ""}}, // Empty value
 				},
 			},
 			"missing_translations": {
 				Localizations: map[string]xcstrings.Localization{
-					"en": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "Missing"}},
+					"en": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Missing"}},
 					// ja is missing
 				},
 			},
@@ -129,8 +129,8 @@ func TestDisplayKeyDetails_OutputFormat(t *testing.T) {
 		Strings: map[string]xcstrings.StringDefinition{
 			"test_key": {
 				Localizations: map[string]xcstrings.Localization{
-					"en": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "Test"}},
-					"ja": {StringUnit: xcstrings.StringUnit{State: "new", Value: "テスト"}},
+					"en": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Test"}},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "new", Value: "テスト"}},
 				},
 			},
 		},
@@ -171,10 +171,10 @@ func TestDisplayKeyDetails_LanguageSorting(t *testing.T) {
 		Strings: map[string]xcstrings.StringDefinition{
 			"sort_test": {
 				Localizations: map[string]xcstrings.Localization{
-					"zh": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "中文"}},
-					"en": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "English"}},
-					"ja": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "日本語"}},
-					"es": {StringUnit: xcstrings.StringUnit{State: "translated", Value: "Español"}},
+					"zh": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "中文"}},
+					"en": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "English"}},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "日本語"}},
+					"es": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Español"}},
 				},
 			},
 		},

--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -26,13 +26,38 @@ type StringDefinition struct {
 
 // Localization represents localization data for a specific language.
 type Localization struct {
-	StringUnit StringUnit `json:"stringUnit"`
+	StringUnit    *StringUnit              `json:"stringUnit,omitempty"`
+	Variations    *Variations              `json:"variations,omitempty"`
+	Substitutions map[string]Substitution  `json:"substitutions,omitempty"`
 }
 
 // StringUnit represents a string unit with translation state and value.
 type StringUnit struct {
 	State string `json:"state"`
 	Value string `json:"value"`
+}
+
+// PluralCategory represents a CLDR plural category.
+type PluralCategory = string
+
+// VariationValue is the recursive building block.
+// It holds either a direct stringUnit or nested variations (not both).
+type VariationValue struct {
+	StringUnit *StringUnit `json:"stringUnit,omitempty"`
+	Variations *Variations `json:"variations,omitempty"`
+}
+
+// Variations holds plural and/or device variation maps.
+type Variations struct {
+	Plural map[PluralCategory]*VariationValue `json:"plural,omitempty"`
+	Device map[string]*VariationValue          `json:"device,omitempty"`
+}
+
+// Substitution represents a single substitution entry.
+type Substitution struct {
+	ArgNum          int        `json:"argNum"`
+	FormatSpecifier string     `json:"formatSpecifier"`
+	Variations      Variations `json:"variations"`
 }
 
 // Load reads and parses an XCStrings file from the given path.
@@ -116,7 +141,7 @@ func (x *XCStrings) UntranslatedKeys(language string) []string {
 			continue
 		}
 		localization, exists := definition.Localizations[language]
-		if !exists || localization.StringUnit.State != "translated" {
+		if !exists || localization.StringUnit == nil || localization.StringUnit.State != "translated" {
 			untranslated = append(untranslated, key)
 		}
 	}
@@ -153,7 +178,7 @@ func (x *XCStrings) SetTranslation(key, language, value string) error {
 	}
 
 	loc := definition.Localizations[language]
-	loc.StringUnit = StringUnit{
+	loc.StringUnit = &StringUnit{
 		State: "translated",
 		Value: value,
 	}
@@ -175,7 +200,7 @@ func (x *XCStrings) KeysWithAnyUntranslated() []string {
 		hasUntranslated := false
 		for _, lang := range languages {
 			localization, exists := definition.Localizations[lang]
-			if !exists || localization.StringUnit.State != "translated" {
+			if !exists || localization.StringUnit == nil || localization.StringUnit.State != "translated" {
 				hasUntranslated = true
 				break
 			}
@@ -193,7 +218,7 @@ func (x *XCStrings) TranslatedKeys(language string) []string {
 	var translated []string
 	for key, definition := range x.Strings {
 		if localization, exists := definition.Localizations[language]; exists {
-			if localization.StringUnit.State == "translated" {
+			if localization.StringUnit != nil && localization.StringUnit.State == "translated" {
 				translated = append(translated, key)
 			}
 		}

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -1,6 +1,7 @@
 package xcstrings
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
@@ -100,25 +101,25 @@ func TestXCStrings_GetUntranslatedKeys(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"translated_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Hello"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "こんにちは"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Hello"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "こんにちは"}},
 				},
 			},
 			"untranslated_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Untranslated"}},
-					"ja": {StringUnit: StringUnit{State: "new", Value: "未翻訳"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Untranslated"}},
+					"ja": {StringUnit: &StringUnit{State: "new", Value: "未翻訳"}},
 				},
 			},
 			"missing_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Missing"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Missing"}},
 				},
 			},
 			"should_not_translate": {
 				ShouldTranslate: func() *bool { b := false; return &b }(),
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Don't translate"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Don't translate"}},
 				},
 			},
 		},
@@ -162,43 +163,43 @@ func TestXCStrings_GetKeysWithAnyUntranslated(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"all_translated": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Hello"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "こんにちは"}},
-					"es": {StringUnit: StringUnit{State: "translated", Value: "Hola"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Hello"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "こんにちは"}},
+					"es": {StringUnit: &StringUnit{State: "translated", Value: "Hola"}},
 				},
 			},
 			"ja_untranslated": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "English"}},
-					"ja": {StringUnit: StringUnit{State: "new", Value: ""}},
-					"es": {StringUnit: StringUnit{State: "translated", Value: "Español"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "English"}},
+					"ja": {StringUnit: &StringUnit{State: "new", Value: ""}},
+					"es": {StringUnit: &StringUnit{State: "translated", Value: "Español"}},
 				},
 			},
 			"es_missing": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "English only"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "日本語"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "English only"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "日本語"}},
 					// es is missing - should be considered untranslated
 				},
 			},
 			"only_en_translated": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "English"}},
-					"ja": {StringUnit: StringUnit{State: "new", Value: ""}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "English"}},
+					"ja": {StringUnit: &StringUnit{State: "new", Value: ""}},
 					// es is missing
 				},
 			},
 			"all_untranslated": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "new", Value: ""}},
-					"ja": {StringUnit: StringUnit{State: "new", Value: ""}},
-					"es": {StringUnit: StringUnit{State: "new", Value: ""}},
+					"en": {StringUnit: &StringUnit{State: "new", Value: ""}},
+					"ja": {StringUnit: &StringUnit{State: "new", Value: ""}},
+					"es": {StringUnit: &StringUnit{State: "new", Value: ""}},
 				},
 			},
 			"should_not_translate": {
 				ShouldTranslate: func() *bool { b := false; return &b }(),
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Don't translate"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Don't translate"}},
 					// ja and es are missing, but this should not appear in untranslated list
 				},
 			},
@@ -221,19 +222,19 @@ func TestXCStrings_ShouldTranslateFlag(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"normal_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Normal"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Normal"}},
 				},
 			},
 			"should_translate_true": {
 				ShouldTranslate: func() *bool { b := true; return &b }(),
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Translate me"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Translate me"}},
 				},
 			},
 			"should_translate_false": {
 				ShouldTranslate: func() *bool { b := false; return &b }(),
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Don't translate"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Don't translate"}},
 				},
 			},
 			"placeholder_key": {
@@ -242,8 +243,8 @@ func TestXCStrings_ShouldTranslateFlag(t *testing.T) {
 			},
 			"already_translated": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Already translated"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "翻訳済み"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Already translated"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "翻訳済み"}},
 				},
 			},
 		},
@@ -274,7 +275,7 @@ func TestXCStrings_SetTranslation(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"existing_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Existing"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Existing"}},
 				},
 			},
 		},
@@ -335,8 +336,8 @@ func TestXCStrings_SetTranslation_PreservesExistingLocalization(t *testing.T) {
 				Comment:         "A greeting message",
 				ExtractionState: "manual",
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Hello"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "こんにちは"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Hello"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "こんにちは"}},
 				},
 			},
 		},
@@ -426,7 +427,7 @@ func TestXCStrings_SaveToFile(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"test_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Test"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Test"}},
 				},
 			},
 		},
@@ -515,7 +516,7 @@ func TestXCStrings_SaveToFile_AtomicWrite(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Value"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Value"}},
 				},
 			},
 		},
@@ -564,7 +565,7 @@ func TestXCStrings_SaveToFile_OverwriteExisting(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"old_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Old"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Old"}},
 				},
 			},
 		},
@@ -583,7 +584,7 @@ func TestXCStrings_SaveToFile_OverwriteExisting(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"new_key": {
 				Localizations: map[string]Localization{
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "New"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "New"}},
 				},
 			},
 		},
@@ -614,17 +615,17 @@ func TestXCStrings_GetTranslatedKeys(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"translated_key": {
 				Localizations: map[string]Localization{
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "翻訳済み"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "翻訳済み"}},
 				},
 			},
 			"untranslated_key": {
 				Localizations: map[string]Localization{
-					"ja": {StringUnit: StringUnit{State: "new", Value: "未翻訳"}},
+					"ja": {StringUnit: &StringUnit{State: "new", Value: "未翻訳"}},
 				},
 			},
 			"missing_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Missing"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Missing"}},
 				},
 			},
 		},
@@ -636,4 +637,195 @@ func TestXCStrings_GetTranslatedKeys(t *testing.T) {
 	sort.Strings(got)
 	sort.Strings(want)
 	test.AssertSliceEqual(t, got, want)
+}
+
+// normalizeJSON re-marshals JSON to produce a canonical form for comparison.
+func normalizeJSON(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("failed to unmarshal JSON for normalization: %v", err)
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal JSON for normalization: %v", err)
+	}
+	return out
+}
+
+// assertRoundTrip loads a fixture, saves it, and verifies the output matches.
+func assertRoundTrip(t *testing.T, fixtureName string) {
+	t.Helper()
+
+	fixturePath := test.FixturePath(fixtureName)
+
+	// Read original fixture
+	originalData, err := os.ReadFile(fixturePath)
+	test.AssertNoError(t, err)
+
+	// Load the fixture
+	xcstringsData, err := Load(fixturePath)
+	test.AssertNoError(t, err)
+
+	// Save to a temp file
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, fixtureName)
+	err = xcstringsData.SaveToFile(outputPath)
+	test.AssertNoError(t, err)
+
+	// Read the saved output
+	savedData, err := os.ReadFile(outputPath)
+	test.AssertNoError(t, err)
+
+	// Normalize both and compare
+	normalizedOriginal := normalizeJSON(t, originalData)
+	normalizedSaved := normalizeJSON(t, savedData)
+
+	if string(normalizedOriginal) != string(normalizedSaved) {
+		t.Errorf("round-trip mismatch for %s\noriginal:\n%s\nsaved:\n%s",
+			fixtureName, string(normalizedOriginal), string(normalizedSaved))
+	}
+
+	// Verify the saved file can be loaded again
+	reloaded, err := Load(outputPath)
+	test.AssertNoError(t, err)
+	if reloaded == nil {
+		t.Fatal("reloaded xcstrings should not be nil")
+	}
+}
+
+func TestRoundTrip_PluralVariations(t *testing.T) {
+	assertRoundTrip(t, "plural_variations.xcstrings")
+
+	// Also verify the structure was parsed correctly
+	fixturePath := test.FixturePath("plural_variations.xcstrings")
+	xcstringsData, err := Load(fixturePath)
+	test.AssertNoError(t, err)
+
+	def := xcstringsData.Strings["item_count"]
+	enLoc := def.Localizations["en"]
+
+	if enLoc.StringUnit != nil {
+		t.Error("expected StringUnit to be nil for variation-based localization")
+	}
+	if enLoc.Variations == nil {
+		t.Fatal("expected Variations to be non-nil")
+	}
+	if enLoc.Variations.Plural == nil {
+		t.Fatal("expected Plural variations to be non-nil")
+	}
+	if len(enLoc.Variations.Plural) != 2 {
+		t.Errorf("expected 2 plural categories, got %d", len(enLoc.Variations.Plural))
+	}
+
+	oneVariation := enLoc.Variations.Plural["one"]
+	if oneVariation == nil || oneVariation.StringUnit == nil {
+		t.Fatal("expected 'one' plural variation with stringUnit")
+	}
+	test.AssertEqual(t, oneVariation.StringUnit.Value, "%lld item")
+
+	otherVariation := enLoc.Variations.Plural["other"]
+	if otherVariation == nil || otherVariation.StringUnit == nil {
+		t.Fatal("expected 'other' plural variation with stringUnit")
+	}
+	test.AssertEqual(t, otherVariation.StringUnit.Value, "%lld items")
+}
+
+func TestRoundTrip_DeviceVariations(t *testing.T) {
+	assertRoundTrip(t, "device_variations.xcstrings")
+
+	fixturePath := test.FixturePath("device_variations.xcstrings")
+	xcstringsData, err := Load(fixturePath)
+	test.AssertNoError(t, err)
+
+	def := xcstringsData.Strings["welcome_message"]
+	enLoc := def.Localizations["en"]
+
+	if enLoc.Variations == nil {
+		t.Fatal("expected Variations to be non-nil")
+	}
+	if enLoc.Variations.Device == nil {
+		t.Fatal("expected Device variations to be non-nil")
+	}
+	if len(enLoc.Variations.Device) != 3 {
+		t.Errorf("expected 3 device categories, got %d", len(enLoc.Variations.Device))
+	}
+
+	iphoneVariation := enLoc.Variations.Device["iphone"]
+	if iphoneVariation == nil || iphoneVariation.StringUnit == nil {
+		t.Fatal("expected 'iphone' device variation with stringUnit")
+	}
+	test.AssertEqual(t, iphoneVariation.StringUnit.Value, "Welcome to our iPhone app")
+}
+
+func TestRoundTrip_NestedVariations(t *testing.T) {
+	assertRoundTrip(t, "nested_variations.xcstrings")
+
+	fixturePath := test.FixturePath("nested_variations.xcstrings")
+	xcstringsData, err := Load(fixturePath)
+	test.AssertNoError(t, err)
+
+	def := xcstringsData.Strings["photo_count"]
+	enLoc := def.Localizations["en"]
+
+	if enLoc.Variations == nil || enLoc.Variations.Device == nil {
+		t.Fatal("expected device variations")
+	}
+
+	iphoneVariation := enLoc.Variations.Device["iphone"]
+	if iphoneVariation == nil {
+		t.Fatal("expected 'iphone' device variation")
+	}
+	if iphoneVariation.StringUnit != nil {
+		t.Error("expected StringUnit to be nil for nested variation")
+	}
+	if iphoneVariation.Variations == nil || iphoneVariation.Variations.Plural == nil {
+		t.Fatal("expected nested plural variations under iphone")
+	}
+
+	oneVariation := iphoneVariation.Variations.Plural["one"]
+	if oneVariation == nil || oneVariation.StringUnit == nil {
+		t.Fatal("expected 'one' plural variation under iphone")
+	}
+	test.AssertEqual(t, oneVariation.StringUnit.Value, "%lld photo on your iPhone")
+}
+
+func TestRoundTrip_Substitutions(t *testing.T) {
+	assertRoundTrip(t, "substitutions.xcstrings")
+
+	fixturePath := test.FixturePath("substitutions.xcstrings")
+	xcstringsData, err := Load(fixturePath)
+	test.AssertNoError(t, err)
+
+	def := xcstringsData.Strings["upload_progress"]
+	enLoc := def.Localizations["en"]
+
+	if enLoc.StringUnit == nil {
+		t.Fatal("expected StringUnit to be non-nil for substitution-based localization")
+	}
+	test.AssertEqual(t, enLoc.StringUnit.Value, "Uploading %#@file_count@ to %#@folder@")
+
+	if enLoc.Substitutions == nil {
+		t.Fatal("expected Substitutions to be non-nil")
+	}
+	if len(enLoc.Substitutions) != 2 {
+		t.Errorf("expected 2 substitutions, got %d", len(enLoc.Substitutions))
+	}
+
+	fileCount := enLoc.Substitutions["file_count"]
+	test.AssertEqual(t, fileCount.ArgNum, 1)
+	test.AssertEqual(t, fileCount.FormatSpecifier, "lld")
+	if fileCount.Variations.Plural == nil {
+		t.Fatal("expected plural variations in file_count substitution")
+	}
+
+	oneVariation := fileCount.Variations.Plural["one"]
+	if oneVariation == nil || oneVariation.StringUnit == nil {
+		t.Fatal("expected 'one' variation in file_count substitution")
+	}
+	test.AssertEqual(t, oneVariation.StringUnit.Value, "%arg file")
+}
+
+func TestRoundTrip_SimpleStringUnit(t *testing.T) {
+	assertRoundTrip(t, "simple.xcstrings")
 }


### PR DESCRIPTION
## Summary
- Add VariationValue, Variations types as recursive building blocks
- Change Localization.StringUnit to *StringUnit (pointer with omitempty)
- Add Variations and Substitutions fields to Localization
- Add PluralCategory type for CLDR plural categories
- Add Substitution type with ArgNum, FormatSpecifier, Variations
- Ensure round-trip fidelity: load→save produces identical JSON
- Add fixtures with plural, device, nested, and substitution variations

## Test plan
- [x] All existing tests pass (no regression)
- [x] Round-trip test: plural variations
- [x] Round-trip test: device variations
- [x] Round-trip test: nested device x plural
- [x] Round-trip test: substitutions
- [x] Simple stringUnit files still work correctly

Closes #23