### PR TITLE
feat: support stale state

### DIFF
--- a/command/stale.go
+++ b/command/stale.go
@@ -1,0 +1,73 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+
+	"github.com/google/subcommands"
+	"xckit/formatter"
+)
+
+type StaleCommand struct {
+	XCStringsCommand
+	remove bool
+	dryRun bool
+}
+
+func (*StaleCommand) Name() string {
+	return "stale"
+}
+
+func (*StaleCommand) Synopsis() string {
+	return "List or remove stale keys"
+}
+
+func (*StaleCommand) Usage() string {
+	return "stale [-f file.xcstrings] [--remove] [--dry-run]: List or remove stale keys\n"
+}
+
+func (c *StaleCommand) SetFlags(f *flag.FlagSet) {
+	c.SetXCStringsFlags(f)
+	f.BoolVar(&c.remove, "remove", false, "Remove stale keys from the file")
+	f.BoolVar(&c.dryRun, "dry-run", false, "Show what would be removed without modifying the file (use with --remove)")
+}
+
+func (c *StaleCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	xcstrings, err := c.LoadXCStrings()
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	staleKeys := xcstrings.StaleKeys()
+	sort.Strings(staleKeys)
+
+	if len(staleKeys) == 0 {
+		fmt.Println("No stale keys found")
+		return subcommands.ExitSuccess
+	}
+
+	if c.remove {
+		if c.dryRun {
+			fmt.Printf("Would remove %d stale key(s):\n", len(staleKeys))
+			for _, key := range staleKeys {
+				fmt.Printf("  %s\n", key)
+			}
+			return subcommands.ExitSuccess
+		}
+
+		count := xcstrings.RemoveStaleKeys()
+		if err := xcstrings.SaveToFile(c.filePath); err != nil {
+			fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+			return subcommands.ExitFailure
+		}
+		fmt.Printf("Removed %d stale key(s)\n", count)
+		return subcommands.ExitSuccess
+	}
+
+	fmt.Printf("Stale keys (%d):\n", len(staleKeys))
+	formatter.DisplayKeyDetails(xcstrings, staleKeys)
+	return subcommands.ExitSuccess
+}

--- a/command/stale_test.go
+++ b/command/stale_test.go
@@ -1,0 +1,180 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"strings"
+	"testing"
+
+	"xckit/helper/test"
+	"xckit/xcstrings"
+)
+
+func TestStaleCommand_Execute_ListStale(t *testing.T) {
+	filePath := test.FixturePath("stale.xcstrings")
+
+	cmd := &StaleCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	expectedContent := []string{
+		"Stale keys (2):",
+		"stale_key",
+		"another_stale_key",
+	}
+
+	for _, expected := range expectedContent {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output should contain %q, got: %q", expected, output)
+		}
+	}
+}
+
+func TestStaleCommand_Execute_NoStale(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"key1": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Key 1"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &StaleCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "No stale keys found") {
+		t.Errorf("output should contain 'No stale keys found', got: %q", output)
+	}
+}
+
+func TestStaleCommand_Execute_DryRun(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"active": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Active"}}
+				}
+			},
+			"old_key": {
+				"extractionState": "stale",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Old"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &StaleCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--remove", "--dry-run"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Would remove 1 stale key(s)") {
+		t.Errorf("output should contain dry-run message, got: %q", output)
+	}
+	if !strings.Contains(output, "old_key") {
+		t.Errorf("output should list old_key, got: %q", output)
+	}
+
+	// Verify file was not modified
+	loaded, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	if len(loaded.Strings) != 2 {
+		t.Errorf("expected 2 keys (file should not be modified), got %d", len(loaded.Strings))
+	}
+}
+
+func TestStaleCommand_Execute_Remove(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"active": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Active"}}
+				}
+			},
+			"old_key": {
+				"extractionState": "stale",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Old"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &StaleCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--remove"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Removed 1 stale key(s)") {
+		t.Errorf("output should contain removal message, got: %q", output)
+	}
+
+	// Verify file was modified
+	loaded, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	if len(loaded.Strings) != 1 {
+		t.Errorf("expected 1 key after removal, got %d", len(loaded.Strings))
+	}
+	if _, exists := loaded.Strings["old_key"]; exists {
+		t.Error("old_key should have been removed")
+	}
+}
+
+func TestStaleCommand_Execute_FileNotFound(t *testing.T) {
+	cmd := &StaleCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(&strings.Builder{})
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", "nonexistent.xcstrings"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 1)
+}

--- a/command/status.go
+++ b/command/status.go
@@ -37,6 +37,8 @@ func (c *StatusCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	}
 
 	totalKeys := len(xcstrings.Strings)
+	staleKeys := xcstrings.StaleKeys()
+	activeKeys := totalKeys - len(staleKeys)
 	languages := xcstrings.Languages()
 	sort.Strings(languages)
 
@@ -44,6 +46,10 @@ func (c *StatusCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	fmt.Printf("==================\n")
 	fmt.Printf("Source Language: %s\n", xcstrings.SourceLanguage)
 	fmt.Printf("Total Keys: %d\n", totalKeys)
+	if len(staleKeys) > 0 {
+		fmt.Printf("Stale Keys: %d\n", len(staleKeys))
+		fmt.Printf("Active Keys: %d\n", activeKeys)
+	}
 	fmt.Printf("Languages: %s\n\n", languages)
 
 	fmt.Printf("Progress by Language:\n")
@@ -52,10 +58,13 @@ func (c *StatusCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	for _, lang := range languages {
 		untranslated := xcstrings.UntranslatedKeys(lang)
 		needsReview := xcstrings.NeedsReviewKeys(lang)
-		translated := totalKeys - len(untranslated)
-		percentage := float64(translated) / float64(totalKeys) * 100
+		translated := activeKeys - len(untranslated)
+		percentage := float64(0)
+		if activeKeys > 0 {
+			percentage = float64(translated) / float64(activeKeys) * 100
+		}
 
-		fmt.Printf("%-6s: %3d/%d translated, %d needs_review (%.1f%%)\n", lang, translated, totalKeys, len(needsReview), percentage)
+		fmt.Printf("%-6s: %3d/%d translated, %d needs_review (%.1f%%)\n", lang, translated, activeKeys, len(needsReview), percentage)
 	}
 
 	return subcommands.ExitSuccess

--- a/fixtures/stale.xcstrings
+++ b/fixtures/stale.xcstrings
@@ -1,0 +1,32 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "active_key": {
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Active"}},
+        "ja": {"stringUnit": {"state": "translated", "value": "アクティブ"}}
+      }
+    },
+    "stale_key": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Stale"}},
+        "ja": {"stringUnit": {"state": "translated", "value": "古い"}}
+      }
+    },
+    "another_stale_key": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Another Stale"}},
+        "ja": {"stringUnit": {"state": "new", "value": ""}}
+      }
+    },
+    "untranslated_key": {
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Untranslated"}},
+        "ja": {"stringUnit": {"state": "new", "value": ""}}
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/formatter/display.go
+++ b/formatter/display.go
@@ -12,7 +12,11 @@ func DisplayKeyDetails(x *xcstrings.XCStrings, keys []string) {
 	sort.Strings(languages)
 
 	for _, key := range keys {
-		fmt.Printf("\n%s:\n", key)
+		if x.IsStale(key) {
+			fmt.Printf("\n%s [stale]:\n", key)
+		} else {
+			fmt.Printf("\n%s:\n", key)
+		}
 		definition := x.Strings[key]
 		for _, lang := range languages {
 			if localization, exists := definition.Localizations[lang]; exists {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ func main() {
 	subcommands.Register(&command.UntranslatedCommand{}, "")
 	subcommands.Register(&command.ListCommand{}, "")
 	subcommands.Register(&command.SetCommand{}, "")
+	subcommands.Register(&command.StaleCommand{}, "")
 	subcommands.Register(&command.StatusCommand{}, "")
 	subcommands.Register(&command.VersionCommand{}, "")
 	subcommands.Register(subcommands.HelpCommand(), "")

--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -108,10 +108,57 @@ func (x *XCStrings) Keys() []string {
 	return keys
 }
 
+// StaleKeys returns keys that have extractionState "stale".
+func (x *XCStrings) StaleKeys() []string {
+	var keys []string
+	for key, def := range x.Strings {
+		if def.ExtractionState == "stale" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+// ActiveKeys returns keys that are not stale (extractionState != "stale").
+func (x *XCStrings) ActiveKeys() []string {
+	var keys []string
+	for key, def := range x.Strings {
+		if def.ExtractionState != "stale" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+// IsStale returns whether the given key has extractionState "stale".
+func (x *XCStrings) IsStale(key string) bool {
+	def, exists := x.Strings[key]
+	if !exists {
+		return false
+	}
+	return def.ExtractionState == "stale"
+}
+
+// RemoveStaleKeys removes all keys with extractionState "stale" from the catalog.
+func (x *XCStrings) RemoveStaleKeys() int {
+	count := 0
+	for key, def := range x.Strings {
+		if def.ExtractionState == "stale" {
+			delete(x.Strings, key)
+			count++
+		}
+	}
+	return count
+}
+
 // UntranslatedKeys returns keys that are not translated for the given language.
+// Stale keys are excluded.
 func (x *XCStrings) UntranslatedKeys(language string) []string {
 	var untranslated []string
 	for key, definition := range x.Strings {
+		if definition.ExtractionState == "stale" {
+			continue
+		}
 		if definition.ShouldTranslate != nil && *definition.ShouldTranslate == false {
 			continue
 		}
@@ -164,11 +211,15 @@ func (x *XCStrings) SetTranslation(key, language, value string) error {
 }
 
 // KeysWithAnyUntranslated returns keys that have at least one untranslated language.
+// Stale keys are excluded.
 func (x *XCStrings) KeysWithAnyUntranslated() []string {
 	var result []string
 	languages := x.Languages()
 
 	for key, definition := range x.Strings {
+		if definition.ExtractionState == "stale" {
+			continue
+		}
 		if definition.ShouldTranslate != nil && *definition.ShouldTranslate == false {
 			continue
 		}

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -684,6 +684,93 @@ func TestXCStrings_NeedsReviewKeys(t *testing.T) {
 	})
 }
 
+func TestXCStrings_StaleKeys(t *testing.T) {
+	xcstrings := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"active_key": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
+					"ja": {StringUnit: StringUnit{State: "translated", Value: "アクティブ"}},
+				},
+			},
+			"stale_key": {
+				ExtractionState: "stale",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Stale"}},
+					"ja": {StringUnit: StringUnit{State: "translated", Value: "古い"}},
+				},
+			},
+			"another_stale": {
+				ExtractionState: "stale",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Another"}},
+				},
+			},
+			"manual_key": {
+				ExtractionState: "manual",
+				Localizations: map[string]Localization{
+					"en": {StringUnit: StringUnit{State: "translated", Value: "Manual"}},
+				},
+			},
+		},
+	}
+
+	t.Run("StaleKeys returns only stale keys", func(t *testing.T) {
+		got := xcstrings.StaleKeys()
+		sort.Strings(got)
+		want := []string{"another_stale", "stale_key"}
+		test.AssertSliceEqual(t, got, want)
+	})
+
+	t.Run("ActiveKeys returns non-stale keys", func(t *testing.T) {
+		got := xcstrings.ActiveKeys()
+		sort.Strings(got)
+		want := []string{"active_key", "manual_key"}
+		test.AssertSliceEqual(t, got, want)
+	})
+
+	t.Run("IsStale returns true for stale keys", func(t *testing.T) {
+		test.AssertEqual(t, xcstrings.IsStale("stale_key"), true)
+		test.AssertEqual(t, xcstrings.IsStale("active_key"), false)
+		test.AssertEqual(t, xcstrings.IsStale("nonexistent"), false)
+	})
+
+	t.Run("UntranslatedKeys excludes stale keys", func(t *testing.T) {
+		// another_stale is missing ja but should not appear since it's stale
+		got := xcstrings.UntranslatedKeys("ja")
+		sort.Strings(got)
+		want := []string{"manual_key"}
+		test.AssertSliceEqual(t, got, want)
+	})
+
+	t.Run("KeysWithAnyUntranslated excludes stale keys", func(t *testing.T) {
+		got := xcstrings.KeysWithAnyUntranslated()
+		sort.Strings(got)
+		// manual_key is missing ja, so it should appear
+		// another_stale is missing ja but is stale, so it should NOT appear
+		want := []string{"manual_key"}
+		test.AssertSliceEqual(t, got, want)
+	})
+
+	t.Run("RemoveStaleKeys removes stale and returns count", func(t *testing.T) {
+		// Create a copy to avoid mutating the shared test struct
+		x := &XCStrings{
+			SourceLanguage: "en",
+			Strings: map[string]StringDefinition{
+				"keep":   {Localizations: map[string]Localization{}},
+				"remove": {ExtractionState: "stale", Localizations: map[string]Localization{}},
+			},
+		}
+		count := x.RemoveStaleKeys()
+		test.AssertEqual(t, count, 1)
+		test.AssertEqual(t, len(x.Strings), 1)
+		if _, exists := x.Strings["remove"]; exists {
+			t.Error("stale key should have been removed")
+		}
+	})
+}
+
 func TestXCStrings_GetTranslatedKeys(t *testing.T) {
 	xcstrings := &XCStrings{
 		SourceLanguage: "en",


### PR DESCRIPTION
## Summary
- Add StaleKeys() and ActiveKeys() methods
- UntranslatedKeys/KeysWithAnyUntranslated exclude stale keys
- Status reports stale separately, excludes from progress
- List shows [stale] marker
- New stale subcommand with --remove and --dry-run

## Test plan
- [x] make test passes (all existing + new tests)

Closes #22