### PR TITLE
feat: support plural variations in query methods

### DIFF
--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -60,6 +60,51 @@ type StringUnit struct {
 	Value string `json:"value"`
 }
 
+// AllStringUnits recursively collects all leaf StringUnit pointers from a Localization.
+// It traverses the top-level StringUnit, Variations (plural/device, possibly nested),
+// and Substitutions to find every StringUnit in the tree.
+func (l *Localization) AllStringUnits() []*StringUnit {
+	var units []*StringUnit
+	if l.StringUnit != nil {
+		units = append(units, l.StringUnit)
+	}
+	if l.Variations != nil {
+		units = append(units, l.Variations.allStringUnits()...)
+	}
+	for _, sub := range l.Substitutions {
+		units = append(units, sub.Variations.allStringUnits()...)
+	}
+	return units
+}
+
+// allStringUnits recursively collects all leaf StringUnit pointers from Variations.
+func (v *Variations) allStringUnits() []*StringUnit {
+	var units []*StringUnit
+	for _, vv := range v.Plural {
+		if vv == nil {
+			continue
+		}
+		if vv.StringUnit != nil {
+			units = append(units, vv.StringUnit)
+		}
+		if vv.Variations != nil {
+			units = append(units, vv.Variations.allStringUnits()...)
+		}
+	}
+	for _, vv := range v.Device {
+		if vv == nil {
+			continue
+		}
+		if vv.StringUnit != nil {
+			units = append(units, vv.StringUnit)
+		}
+		if vv.Variations != nil {
+			units = append(units, vv.Variations.allStringUnits()...)
+		}
+	}
+	return units
+}
+
 // Load reads and parses an XCStrings file from the given path.
 func Load(path string) (*XCStrings, error) {
 	data, err := os.ReadFile(path)
@@ -177,7 +222,8 @@ func (x *XCStrings) RemoveStaleKeys() int {
 }
 
 // UntranslatedKeys returns keys that are not translated for the given language.
-// Stale keys are excluded.
+// A key is untranslated if any leaf StringUnit (including within variations and
+// substitutions) does not have the "translated" state. Stale keys are excluded.
 func (x *XCStrings) UntranslatedKeys(language string) []string {
 	var untranslated []string
 	for key, definition := range x.Strings {
@@ -188,8 +234,20 @@ func (x *XCStrings) UntranslatedKeys(language string) []string {
 			continue
 		}
 		localization, exists := definition.Localizations[language]
-		if !exists || localization.StringUnit == nil || localization.StringUnit.State != "translated" {
+		if !exists {
 			untranslated = append(untranslated, key)
+			continue
+		}
+		units := localization.AllStringUnits()
+		if len(units) == 0 {
+			untranslated = append(untranslated, key)
+			continue
+		}
+		for _, u := range units {
+			if u.State != "translated" {
+				untranslated = append(untranslated, key)
+				break
+			}
 		}
 	}
 	return untranslated
@@ -236,6 +294,8 @@ func (x *XCStrings) SetTranslation(key, language, value string) error {
 }
 
 // KeysWithAnyUntranslated returns keys that have at least one untranslated language.
+// A language is considered untranslated if any leaf StringUnit (including within
+// variations and substitutions) does not have the "translated" state.
 // Stale keys are excluded.
 func (x *XCStrings) KeysWithAnyUntranslated() []string {
 	var result []string
@@ -251,8 +311,22 @@ func (x *XCStrings) KeysWithAnyUntranslated() []string {
 		hasUntranslated := false
 		for _, lang := range languages {
 			localization, exists := definition.Localizations[lang]
-			if !exists || localization.StringUnit == nil || localization.StringUnit.State != "translated" {
+			if !exists {
 				hasUntranslated = true
+				break
+			}
+			units := localization.AllStringUnits()
+			if len(units) == 0 {
+				hasUntranslated = true
+				break
+			}
+			for _, u := range units {
+				if u.State != "translated" {
+					hasUntranslated = true
+					break
+				}
+			}
+			if hasUntranslated {
 				break
 			}
 		}
@@ -280,13 +354,28 @@ func (x *XCStrings) NeedsReviewKeys(language string) []string {
 }
 
 // TranslatedKeys returns keys that are translated for the given language.
+// A key is translated only if all leaf StringUnits (including within variations
+// and substitutions) have the "translated" state.
 func (x *XCStrings) TranslatedKeys(language string) []string {
 	var translated []string
 	for key, definition := range x.Strings {
-		if localization, exists := definition.Localizations[language]; exists {
-			if localization.StringUnit != nil && localization.StringUnit.State == "translated" {
-				translated = append(translated, key)
+		localization, exists := definition.Localizations[language]
+		if !exists {
+			continue
+		}
+		units := localization.AllStringUnits()
+		if len(units) == 0 {
+			continue
+		}
+		allTranslated := true
+		for _, u := range units {
+			if u.State != "translated" {
+				allTranslated = false
+				break
 			}
+		}
+		if allTranslated {
+			translated = append(translated, key)
 		}
 	}
 	return translated

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -690,27 +690,27 @@ func TestXCStrings_StaleKeys(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"active_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "アクティブ"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Active"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "アクティブ"}},
 				},
 			},
 			"stale_key": {
 				ExtractionState: "stale",
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Stale"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "古い"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Stale"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "古い"}},
 				},
 			},
 			"another_stale": {
 				ExtractionState: "stale",
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Another"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Another"}},
 				},
 			},
 			"manual_key": {
 				ExtractionState: "manual",
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Manual"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Manual"}},
 				},
 			},
 		},
@@ -769,6 +769,206 @@ func TestXCStrings_StaleKeys(t *testing.T) {
 			t.Error("stale key should have been removed")
 		}
 	})
+}
+
+func TestLocalization_AllStringUnits(t *testing.T) {
+	t.Run("top-level StringUnit only", func(t *testing.T) {
+		loc := Localization{
+			StringUnit: &StringUnit{State: "translated", Value: "Hello"},
+		}
+		units := loc.AllStringUnits()
+		if len(units) != 1 {
+			t.Fatalf("expected 1 unit, got %d", len(units))
+		}
+		test.AssertEqual(t, units[0].Value, "Hello")
+	})
+
+	t.Run("plural variations", func(t *testing.T) {
+		loc := Localization{
+			Variations: &Variations{
+				Plural: map[PluralCategory]*VariationValue{
+					"one":   {StringUnit: &StringUnit{State: "translated", Value: "1 item"}},
+					"other": {StringUnit: &StringUnit{State: "translated", Value: "%lld items"}},
+				},
+			},
+		}
+		units := loc.AllStringUnits()
+		if len(units) != 2 {
+			t.Fatalf("expected 2 units, got %d", len(units))
+		}
+	})
+
+	t.Run("substitutions", func(t *testing.T) {
+		loc := Localization{
+			StringUnit: &StringUnit{State: "translated", Value: "%#@files@"},
+			Substitutions: map[string]Substitution{
+				"files": {
+					ArgNum:          1,
+					FormatSpecifier: "lld",
+					Variations: Variations{
+						Plural: map[PluralCategory]*VariationValue{
+							"one":   {StringUnit: &StringUnit{State: "translated", Value: "%arg file"}},
+							"other": {StringUnit: &StringUnit{State: "translated", Value: "%arg files"}},
+						},
+					},
+				},
+			},
+		}
+		units := loc.AllStringUnits()
+		// 1 top-level + 2 from substitution
+		if len(units) != 3 {
+			t.Fatalf("expected 3 units, got %d", len(units))
+		}
+	})
+
+	t.Run("empty localization", func(t *testing.T) {
+		loc := Localization{}
+		units := loc.AllStringUnits()
+		if len(units) != 0 {
+			t.Fatalf("expected 0 units, got %d", len(units))
+		}
+	})
+}
+
+func TestUntranslatedKeys_WithVariations(t *testing.T) {
+	xc := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"all_translated_plural": {
+				Localizations: map[string]Localization{
+					"ja": {
+						Variations: &Variations{
+							Plural: map[PluralCategory]*VariationValue{
+								"other": {StringUnit: &StringUnit{State: "translated", Value: "%lld個"}},
+							},
+						},
+					},
+				},
+			},
+			"partial_plural": {
+				Localizations: map[string]Localization{
+					"ja": {
+						Variations: &Variations{
+							Plural: map[PluralCategory]*VariationValue{
+								"one":   {StringUnit: &StringUnit{State: "new", Value: ""}},
+								"other": {StringUnit: &StringUnit{State: "translated", Value: "%lld個"}},
+							},
+						},
+					},
+				},
+			},
+			"simple_translated": {
+				Localizations: map[string]Localization{
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "翻訳済み"}},
+				},
+			},
+		},
+	}
+
+	got := xc.UntranslatedKeys("ja")
+	sort.Strings(got)
+	want := []string{"partial_plural"}
+	test.AssertSliceEqual(t, got, want)
+}
+
+func TestTranslatedKeys_WithVariations(t *testing.T) {
+	xc := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"all_translated_plural": {
+				Localizations: map[string]Localization{
+					"ja": {
+						Variations: &Variations{
+							Plural: map[PluralCategory]*VariationValue{
+								"other": {StringUnit: &StringUnit{State: "translated", Value: "%lld個"}},
+							},
+						},
+					},
+				},
+			},
+			"partial_plural": {
+				Localizations: map[string]Localization{
+					"ja": {
+						Variations: &Variations{
+							Plural: map[PluralCategory]*VariationValue{
+								"one":   {StringUnit: &StringUnit{State: "new", Value: ""}},
+								"other": {StringUnit: &StringUnit{State: "translated", Value: "%lld個"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := xc.TranslatedKeys("ja")
+	sort.Strings(got)
+	want := []string{"all_translated_plural"}
+	test.AssertSliceEqual(t, got, want)
+}
+
+func TestKeysWithAnyUntranslated_WithVariations(t *testing.T) {
+	xc := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"all_translated": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Hello"}},
+					"ja": {
+						Variations: &Variations{
+							Plural: map[PluralCategory]*VariationValue{
+								"other": {StringUnit: &StringUnit{State: "translated", Value: "%lld個"}},
+							},
+						},
+					},
+				},
+			},
+			"partial_variation": {
+				Localizations: map[string]Localization{
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Hello"}},
+					"ja": {
+						Variations: &Variations{
+							Plural: map[PluralCategory]*VariationValue{
+								"one":   {StringUnit: &StringUnit{State: "new", Value: ""}},
+								"other": {StringUnit: &StringUnit{State: "translated", Value: "%lld個"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := xc.KeysWithAnyUntranslated()
+	sort.Strings(got)
+	want := []string{"partial_variation"}
+	test.AssertSliceEqual(t, got, want)
+}
+
+func TestUntranslatedKeys_WithPluralVariationsFixture(t *testing.T) {
+	xc, err := Load("../fixtures/plural_variations.xcstrings")
+	test.AssertNoError(t, err)
+
+	// All variations in the fixture are "translated", so no untranslated keys expected
+	got := xc.UntranslatedKeys("ja")
+	if len(got) != 0 {
+		t.Errorf("expected 0 untranslated keys for ja, got %d: %v", len(got), got)
+	}
+
+	got = xc.UntranslatedKeys("en")
+	if len(got) != 0 {
+		t.Errorf("expected 0 untranslated keys for en, got %d: %v", len(got), got)
+	}
+
+	// TranslatedKeys should return the key for both languages
+	translated := xc.TranslatedKeys("ja")
+	sort.Strings(translated)
+	want := []string{"%lld items"}
+	test.AssertSliceEqual(t, translated, want)
+
+	translated = xc.TranslatedKeys("en")
+	sort.Strings(translated)
+	test.AssertSliceEqual(t, translated, want)
 }
 
 func TestXCStrings_GetTranslatedKeys(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add AllStringUnits() helper on Localization for recursive leaf collection
- UntranslatedKeys/TranslatedKeys/KeysWithAnyUntranslated now traverse variation trees

## Test plan
- [x] make test passes

Closes #18