### PR TITLE
feat: support device variations in display

### DIFF
--- a/formatter/display.go
+++ b/formatter/display.go
@@ -18,21 +18,112 @@ func DisplayKeyDetails(x *xcstrings.XCStrings, keys []string) {
 			fmt.Printf("\n%s:\n", key)
 		}
 		definition := x.Strings[key]
-		for _, lang := range languages {
+
+		// Build the full list of languages to display: non-source languages
+		// from the catalog plus any language in this key's localizations that
+		// has variations (which may include the source language).
+		langSet := make(map[string]bool)
+		for _, l := range languages {
+			langSet[l] = true
+		}
+		for l, loc := range definition.Localizations {
+			if loc.Variations != nil {
+				langSet[l] = true
+			}
+		}
+		allLangs := make([]string, 0, len(langSet))
+		for l := range langSet {
+			allLangs = append(allLangs, l)
+		}
+		sort.Strings(allLangs)
+
+		for _, lang := range allLangs {
 			if localization, exists := definition.Localizations[lang]; exists {
 				if localization.StringUnit != nil {
-					state := localization.StringUnit.State
-					value := localization.StringUnit.Value
-					if value == "" {
-						value = "(empty)"
-					}
-					fmt.Printf("  %s: %s - %s\n", lang, state, value)
+					displayStringUnit(lang, "", localization.StringUnit)
+				} else if localization.Variations != nil {
+					displayVariations(lang, localization.Variations)
 				} else {
-					fmt.Printf("  %s: (variations)\n", lang)
+					fmt.Printf("  %s: missing\n", lang)
 				}
 			} else {
 				fmt.Printf("  %s: missing\n", lang)
 			}
+		}
+	}
+}
+
+func displayStringUnit(lang, prefix string, su *xcstrings.StringUnit) {
+	state := su.State
+	value := su.Value
+	if value == "" {
+		value = "(empty)"
+	}
+	if prefix != "" {
+		fmt.Printf("  %s:\n    %s: %s - %s\n", lang, prefix, state, value)
+	} else {
+		fmt.Printf("  %s: %s - %s\n", lang, state, value)
+	}
+}
+
+func displayVariations(lang string, v *xcstrings.Variations) {
+	if v.Device != nil {
+		displayDeviceVariations(lang, v.Device)
+	} else if v.Plural != nil {
+		displayPluralVariations(lang, "", v.Plural)
+	}
+}
+
+func displayDeviceVariations(lang string, device map[string]*xcstrings.VariationValue) {
+	deviceNames := make([]string, 0, len(device))
+	for name := range device {
+		deviceNames = append(deviceNames, name)
+	}
+	sort.Strings(deviceNames)
+
+	fmt.Printf("  %s:\n", lang)
+	for _, name := range deviceNames {
+		vv := device[name]
+		if vv == nil {
+			continue
+		}
+		if vv.StringUnit != nil {
+			state := vv.StringUnit.State
+			value := vv.StringUnit.Value
+			if value == "" {
+				value = "(empty)"
+			}
+			fmt.Printf("    device.%s: %s - %s\n", name, state, value)
+		} else if vv.Variations != nil && vv.Variations.Plural != nil {
+			displayPluralVariations("", fmt.Sprintf("    device.%s", name), vv.Variations.Plural)
+		}
+	}
+}
+
+func displayPluralVariations(lang, prefix string, plural map[xcstrings.PluralCategory]*xcstrings.VariationValue) {
+	categories := make([]string, 0, len(plural))
+	for cat := range plural {
+		categories = append(categories, cat)
+	}
+	sort.Strings(categories)
+
+	if lang != "" {
+		fmt.Printf("  %s:\n", lang)
+	}
+	for _, cat := range categories {
+		vv := plural[cat]
+		if vv == nil || vv.StringUnit == nil {
+			continue
+		}
+		state := vv.StringUnit.State
+		value := vv.StringUnit.Value
+		if value == "" {
+			value = "(empty)"
+		}
+		if prefix != "" {
+			fmt.Printf("%s.plural.%s: %s - %s\n", prefix, cat, state, value)
+		} else {
+			fmt.Printf("    plural.%s: %s - %s\n", cat, state, value)
 		}
 	}
 }

--- a/formatter/display_test.go
+++ b/formatter/display_test.go
@@ -165,6 +165,138 @@ func TestDisplayKeyDetails_OutputFormat(t *testing.T) {
 	}
 }
 
+func TestDisplayKeyDetails_DeviceVariations(t *testing.T) {
+	xcstringsData := &xcstrings.XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]xcstrings.StringDefinition{
+			"welcome_message": {
+				Localizations: map[string]xcstrings.Localization{
+					"en": {
+						Variations: &xcstrings.Variations{
+							Device: map[string]*xcstrings.VariationValue{
+								"iphone": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Welcome to our iPhone app!"}},
+								"ipad":   {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Welcome to our iPad app!"}},
+								"other":  {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Welcome to our app!"}},
+							},
+						},
+					},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "ようこそ"}},
+				},
+			},
+		},
+	}
+
+	output := captureOutput(func() {
+		DisplayKeyDetails(xcstringsData, []string{"welcome_message"})
+	})
+
+	expectedPatterns := []string{
+		"welcome_message:",
+		"device.ipad: translated - Welcome to our iPad app!",
+		"device.iphone: translated - Welcome to our iPhone app!",
+		"device.other: translated - Welcome to our app!",
+		"ja: translated - ようこそ",
+	}
+
+	for _, expected := range expectedPatterns {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected output to contain %q, got:\n%s", expected, output)
+		}
+	}
+}
+
+func TestDisplayKeyDetails_NestedDevicePluralVariations(t *testing.T) {
+	xcstringsData := &xcstrings.XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]xcstrings.StringDefinition{
+			"%lld photos": {
+				Localizations: map[string]xcstrings.Localization{
+					"en": {
+						Variations: &xcstrings.Variations{
+							Device: map[string]*xcstrings.VariationValue{
+								"iphone": {
+									Variations: &xcstrings.Variations{
+										Plural: map[string]*xcstrings.VariationValue{
+											"one":   {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "%lld photo on iPhone"}},
+											"other": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "%lld photos on iPhone"}},
+										},
+									},
+								},
+								"other": {
+									Variations: &xcstrings.Variations{
+										Plural: map[string]*xcstrings.VariationValue{
+											"one":   {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "%lld photo"}},
+											"other": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "%lld photos"}},
+										},
+									},
+								},
+							},
+						},
+					},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "%lld枚の写真"}},
+				},
+			},
+		},
+	}
+
+	output := captureOutput(func() {
+		DisplayKeyDetails(xcstringsData, []string{"%lld photos"})
+	})
+
+	expectedPatterns := []string{
+		"%lld photos:",
+		"device.iphone.plural.one: translated - %lld photo on iPhone",
+		"device.iphone.plural.other: translated - %lld photos on iPhone",
+		"device.other.plural.one: translated - %lld photo",
+		"device.other.plural.other: translated - %lld photos",
+		"ja: translated - %lld枚の写真",
+	}
+
+	for _, expected := range expectedPatterns {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected output to contain %q, got:\n%s", expected, output)
+		}
+	}
+}
+
+func TestDisplayKeyDetails_PluralVariations(t *testing.T) {
+	xcstringsData := &xcstrings.XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]xcstrings.StringDefinition{
+			"%lld items": {
+				Localizations: map[string]xcstrings.Localization{
+					"en": {
+						Variations: &xcstrings.Variations{
+							Plural: map[string]*xcstrings.VariationValue{
+								"one":   {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "%lld item"}},
+								"other": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "%lld items"}},
+							},
+						},
+					},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "%lld個"}},
+				},
+			},
+		},
+	}
+
+	output := captureOutput(func() {
+		DisplayKeyDetails(xcstringsData, []string{"%lld items"})
+	})
+
+	expectedPatterns := []string{
+		"%lld items:",
+		"plural.one: translated - %lld item",
+		"plural.other: translated - %lld items",
+		"ja: translated - %lld個",
+	}
+
+	for _, expected := range expectedPatterns {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected output to contain %q, got:\n%s", expected, output)
+		}
+	}
+}
+
 func TestDisplayKeyDetails_LanguageSorting(t *testing.T) {
 	xcstringsData := &xcstrings.XCStrings{
 		SourceLanguage: "en",

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -690,27 +690,27 @@ func TestXCStrings_StaleKeys(t *testing.T) {
 		Strings: map[string]StringDefinition{
 			"active_key": {
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Active"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "アクティブ"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Active"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "アクティブ"}},
 				},
 			},
 			"stale_key": {
 				ExtractionState: "stale",
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Stale"}},
-					"ja": {StringUnit: StringUnit{State: "translated", Value: "古い"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Stale"}},
+					"ja": {StringUnit: &StringUnit{State: "translated", Value: "古い"}},
 				},
 			},
 			"another_stale": {
 				ExtractionState: "stale",
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Another"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Another"}},
 				},
 			},
 			"manual_key": {
 				ExtractionState: "manual",
 				Localizations: map[string]Localization{
-					"en": {StringUnit: StringUnit{State: "translated", Value: "Manual"}},
+					"en": {StringUnit: &StringUnit{State: "translated", Value: "Manual"}},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- DisplayKeyDetails renders device variation entries with `device.*` prefix
- Supports nested device x plural display (e.g. `device.iphone.plural.one`)
- Plural-only variations also rendered with `plural.*` prefix
- Source language localizations with variations are now included in display output
- Fixed pre-existing compile error in xcstrings_test.go (StringUnit pointer types)

## Test plan
- [x] make test passes

Closes #19