### PR TITLE
feat: add stringUnit-level counting to status command

### DIFF
--- a/command/status.go
+++ b/command/status.go
@@ -64,7 +64,38 @@ func (c *StatusCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 			percentage = float64(translated) / float64(activeKeys) * 100
 		}
 
-		fmt.Printf("%-6s: %3d/%d translated, %d needs_review (%.1f%%)\n", lang, translated, activeKeys, len(needsReview), percentage)
+		totalUnits := 0
+		translatedUnits := 0
+		for _, key := range xcstrings.ActiveKeys() {
+			def := xcstrings.Strings[key]
+			if def.ShouldTranslate != nil && *def.ShouldTranslate == false {
+				continue
+			}
+			loc, exists := def.Localizations[lang]
+			if !exists {
+				totalUnits++
+				continue
+			}
+			units := loc.AllStringUnits()
+			if len(units) == 0 {
+				totalUnits++
+				continue
+			}
+			totalUnits += len(units)
+			for _, u := range units {
+				if u.State == "translated" {
+					translatedUnits++
+				}
+			}
+		}
+		unitsPercentage := float64(0)
+		if totalUnits > 0 {
+			unitsPercentage = float64(translatedUnits) / float64(totalUnits) * 100
+		}
+
+		fmt.Printf("%-6s: Keys %3d/%d (%.1f%%), Strings %3d/%d (%.1f%%), %d needs_review\n",
+			lang, translated, activeKeys, percentage,
+			translatedUnits, totalUnits, unitsPercentage, len(needsReview))
 	}
 
 	return subcommands.ExitSuccess

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -48,8 +48,9 @@ func TestStatusCommand_Execute(t *testing.T) {
 		"Source Language: en",
 		"Total Keys: 2",
 		"Languages:",
-		"en",
 		"ja",
+		"Keys",
+		"Strings",
 		"needs_review",
 	}
 
@@ -103,6 +104,72 @@ func TestStatusCommand_Execute_WithNeedsReview(t *testing.T) {
 	expectedContent := []string{
 		"Total Keys: 3",
 		"1 needs_review",
+		"Keys",
+		"Strings",
+	}
+
+	for _, expected := range expectedContent {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output should contain %q, got: %q", expected, output)
+		}
+	}
+}
+
+func TestStatusCommand_Execute_WithVariations(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"item_count": {
+				"localizations": {
+					"ja": {
+						"variations": {
+							"plural": {
+								"one": {"stringUnit": {"state": "translated", "value": "%d アイテム"}},
+								"other": {"stringUnit": {"state": "translated", "value": "%d アイテム"}}
+							}
+						}
+					}
+				}
+			},
+			"simple_key": {
+				"localizations": {
+					"ja": {"stringUnit": {"state": "translated", "value": "シンプル"}}
+				}
+			},
+			"partial_key": {
+				"localizations": {
+					"ja": {
+						"variations": {
+							"plural": {
+								"one": {"stringUnit": {"state": "translated", "value": "%d 個"}},
+								"other": {"stringUnit": {"state": "new", "value": ""}}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &StatusCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	expectedContent := []string{
+		"Total Keys: 3",
+		"Keys   2/3",
+		"Strings   4/5",
 	}
 
 	for _, expected := range expectedContent {


### PR DESCRIPTION
## Summary
- Status command now shows both key-level and stringUnit-level translation progress per language
- Gives accurate work-remaining metric for keys with plural/device variations and substitutions

## Test plan
- [x] make test passes

Closes #26