### PR TITLE
feat: add --detail flag to untranslated command

### DIFF
--- a/command/untranslated.go
+++ b/command/untranslated.go
@@ -5,15 +5,18 @@ import (
 	"flag"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/google/subcommands"
 	"xckit/formatter"
+	"xckit/xcstrings"
 )
 
 type UntranslatedCommand struct {
 	XCStringsCommand
 	language string
 	prefix   string
+	detail   bool
 }
 
 func (*UntranslatedCommand) Name() string {
@@ -32,23 +35,28 @@ func (c *UntranslatedCommand) SetFlags(f *flag.FlagSet) {
 	c.SetXCStringsFlags(f)
 	f.StringVar(&c.language, "lang", "", "Target language code (e.g., ja, fr, de) - optional")
 	f.StringVar(&c.prefix, "prefix", "", "Filter keys by prefix")
+	f.BoolVar(&c.detail, "detail", false, "Show per-variation-path untranslated details")
 }
 
 func (c *UntranslatedCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	xcstrings, err := c.LoadXCStrings()
+	xcs, err := c.LoadXCStrings()
 	if err != nil {
 		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
 		return subcommands.ExitFailure
 	}
 
-	var untranslatedKeys []string
-	if c.language != "" {
-		untranslatedKeys = xcstrings.UntranslatedKeys(c.language)
-	} else {
-		untranslatedKeys = xcstrings.KeysWithAnyUntranslated()
+	if c.detail {
+		return c.executeDetail(xcs)
 	}
 
-	untranslatedKeys = xcstrings.FilterKeysByPrefix(untranslatedKeys, c.prefix)
+	var untranslatedKeys []string
+	if c.language != "" {
+		untranslatedKeys = xcs.UntranslatedKeys(c.language)
+	} else {
+		untranslatedKeys = xcs.KeysWithAnyUntranslated()
+	}
+
+	untranslatedKeys = xcs.FilterKeysByPrefix(untranslatedKeys, c.prefix)
 	sort.Strings(untranslatedKeys)
 
 	if len(untranslatedKeys) == 0 {
@@ -74,6 +82,55 @@ func (c *UntranslatedCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...i
 		fmt.Println("Keys with untranslated content:")
 	}
 
-	formatter.DisplayKeyDetails(xcstrings, untranslatedKeys)
+	formatter.DisplayKeyDetails(xcs, untranslatedKeys)
+	return subcommands.ExitSuccess
+}
+
+func (c *UntranslatedCommand) executeDetail(xcs *xcstrings.XCStrings) subcommands.ExitStatus {
+	var details []xcstrings.UntranslatedDetail
+	if c.language != "" {
+		details = xcs.UntranslatedDetailsForLanguage(c.language)
+	} else {
+		details = xcs.UntranslatedDetailsForAllLanguages()
+	}
+
+	// Filter by prefix
+	if c.prefix != "" {
+		var filtered []xcstrings.UntranslatedDetail
+		for _, d := range details {
+			if strings.HasPrefix(d.Key, c.prefix) {
+				filtered = append(filtered, d)
+			}
+		}
+		details = filtered
+	}
+
+	if len(details) == 0 {
+		if c.prefix != "" && c.language != "" {
+			fmt.Printf("No untranslated keys found with prefix '%s' for language '%s'\n", c.prefix, c.language)
+		} else if c.prefix != "" {
+			fmt.Printf("No untranslated keys found with prefix '%s'\n", c.prefix)
+		} else if c.language != "" {
+			fmt.Printf("All keys are translated for language '%s'\n", c.language)
+		} else {
+			fmt.Println("All keys are fully translated in all languages")
+		}
+		return subcommands.ExitSuccess
+	}
+
+	// Sort by key, then language, then path
+	sort.Slice(details, func(i, j int) bool {
+		if details[i].Key != details[j].Key {
+			return details[i].Key < details[j].Key
+		}
+		if details[i].Language != details[j].Language {
+			return details[i].Language < details[j].Language
+		}
+		return details[i].Path < details[j].Path
+	})
+
+	for _, d := range details {
+		fmt.Printf("%s > %s > %s\n", d.Key, d.Language, d.Path)
+	}
 	return subcommands.ExitSuccess
 }

--- a/command/untranslated_test.go
+++ b/command/untranslated_test.go
@@ -255,6 +255,289 @@ func TestUntranslatedCommand_Execute_FileNotFound(t *testing.T) {
 	test.AssertEqual(t, int(status), 1) // ExitFailure
 }
 
+func TestUntranslatedCommand_Execute_Detail(t *testing.T) {
+	tests := []struct {
+		name             string
+		content          string
+		args             []string
+		shouldContain    []string
+		shouldNotContain []string
+	}{
+		{
+			name: "detail with plural variations untranslated",
+			args: []string{"--detail", "--lang", "ja"},
+			content: `{
+				"sourceLanguage": "en",
+				"strings": {
+					"%lld items": {
+						"localizations": {
+							"en": {
+								"variations": {
+									"plural": {
+										"one": {"stringUnit": {"state": "translated", "value": "%lld item"}},
+										"other": {"stringUnit": {"state": "translated", "value": "%lld items"}}
+									}
+								}
+							},
+							"ja": {
+								"variations": {
+									"plural": {
+										"other": {"stringUnit": {"state": "new", "value": ""}}
+									}
+								}
+							}
+						}
+					},
+					"greeting": {
+						"localizations": {
+							"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+							"ja": {"stringUnit": {"state": "translated", "value": "こんにちは"}}
+						}
+					}
+				},
+				"version": "1.0"
+			}`,
+			shouldContain:    []string{"%lld items > ja > plural.other"},
+			shouldNotContain: []string{"greeting"},
+		},
+		{
+			name: "detail with substitutions untranslated",
+			args: []string{"--detail", "--lang", "ja"},
+			content: `{
+				"sourceLanguage": "en",
+				"strings": {
+					"%lld files in %lld folders": {
+						"localizations": {
+							"en": {
+								"stringUnit": {"state": "translated", "value": "%#@files@ in %#@folders@"},
+								"substitutions": {
+									"files": {
+										"argNum": 1, "formatSpecifier": "lld",
+										"variations": {"plural": {"one": {"stringUnit": {"state": "translated", "value": "%arg file"}}, "other": {"stringUnit": {"state": "translated", "value": "%arg files"}}}}
+									},
+									"folders": {
+										"argNum": 2, "formatSpecifier": "lld",
+										"variations": {"plural": {"one": {"stringUnit": {"state": "translated", "value": "%arg folder"}}, "other": {"stringUnit": {"state": "translated", "value": "%arg folders"}}}}
+									}
+								}
+							},
+							"ja": {
+								"stringUnit": {"state": "translated", "value": "%#@files@（%#@folders@内）"},
+								"substitutions": {
+									"files": {
+										"argNum": 1, "formatSpecifier": "lld",
+										"variations": {"plural": {"other": {"stringUnit": {"state": "new", "value": ""}}}}
+									},
+									"folders": {
+										"argNum": 2, "formatSpecifier": "lld",
+										"variations": {"plural": {"other": {"stringUnit": {"state": "translated", "value": "%arg個のフォルダ"}}}}
+									}
+								}
+							}
+						}
+					}
+				},
+				"version": "1.0"
+			}`,
+			shouldContain:    []string{"%lld files in %lld folders > ja > substitutions.files.plural.other"},
+			shouldNotContain: []string{"substitutions.folders"},
+		},
+		{
+			name: "detail with device variations untranslated",
+			args: []string{"--detail", "--lang", "ja"},
+			content: `{
+				"sourceLanguage": "en",
+				"strings": {
+					"welcome_message": {
+						"localizations": {
+							"en": {
+								"variations": {
+									"device": {
+										"iphone": {"stringUnit": {"state": "translated", "value": "Welcome iPhone"}},
+										"ipad": {"stringUnit": {"state": "translated", "value": "Welcome iPad"}},
+										"other": {"stringUnit": {"state": "translated", "value": "Welcome"}}
+									}
+								}
+							},
+							"ja": {
+								"variations": {
+									"device": {
+										"iphone": {"stringUnit": {"state": "new", "value": ""}},
+										"ipad": {"stringUnit": {"state": "translated", "value": "iPadへようこそ"}},
+										"other": {"stringUnit": {"state": "translated", "value": "ようこそ"}}
+									}
+								}
+							}
+						}
+					}
+				},
+				"version": "1.0"
+			}`,
+			shouldContain:    []string{"welcome_message > ja > device.iphone"},
+			shouldNotContain: []string{"device.ipad", "device.other"},
+		},
+		{
+			name: "detail with missing language",
+			args: []string{"--detail", "--lang", "fr"},
+			content: `{
+				"sourceLanguage": "en",
+				"strings": {
+					"greeting": {
+						"localizations": {
+							"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+							"ja": {"stringUnit": {"state": "translated", "value": "こんにちは"}}
+						}
+					}
+				},
+				"version": "1.0"
+			}`,
+			shouldContain: []string{"greeting > fr > missing"},
+		},
+		{
+			name: "detail all translated shows nothing",
+			args: []string{"--detail", "--lang", "ja"},
+			content: `{
+				"sourceLanguage": "en",
+				"strings": {
+					"greeting": {
+						"localizations": {
+							"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+							"ja": {"stringUnit": {"state": "translated", "value": "こんにちは"}}
+						}
+					}
+				},
+				"version": "1.0"
+			}`,
+			shouldContain: []string{"All keys are translated for language 'ja'"},
+		},
+		{
+			name: "detail without lang shows all languages",
+			args: []string{"--detail"},
+			content: `{
+				"sourceLanguage": "en",
+				"strings": {
+					"greeting": {
+						"localizations": {
+							"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+							"ja": {"stringUnit": {"state": "new", "value": ""}},
+							"es": {"stringUnit": {"state": "new", "value": ""}}
+						}
+					}
+				},
+				"version": "1.0"
+			}`,
+			shouldContain: []string{"greeting > ja > new", "greeting > es > new"},
+		},
+		{
+			name: "detail with prefix filter",
+			args: []string{"--detail", "--lang", "ja", "--prefix", "error"},
+			content: `{
+				"sourceLanguage": "en",
+				"strings": {
+					"error.network": {
+						"localizations": {
+							"en": {"stringUnit": {"state": "translated", "value": "Network Error"}},
+							"ja": {"stringUnit": {"state": "new", "value": ""}}
+						}
+					},
+					"greeting": {
+						"localizations": {
+							"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+							"ja": {"stringUnit": {"state": "new", "value": ""}}
+						}
+					}
+				},
+				"version": "1.0"
+			}`,
+			shouldContain:    []string{"error.network > ja"},
+			shouldNotContain: []string{"greeting"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := test.TempFile(t, "test.xcstrings", tt.content)
+
+			cmd := &UntranslatedCommand{}
+			flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+			cmd.SetFlags(flagSet)
+
+			args := append([]string{"-f", filePath}, tt.args...)
+			err := flagSet.Parse(args)
+			test.AssertNoError(t, err)
+
+			output := captureOutput(func() {
+				status := cmd.Execute(context.Background(), flagSet)
+				test.AssertEqual(t, int(status), 0)
+			})
+
+			for _, expected := range tt.shouldContain {
+				if !strings.Contains(output, expected) {
+					t.Errorf("output should contain %q, got: %q", expected, output)
+				}
+			}
+			for _, notExpected := range tt.shouldNotContain {
+				if strings.Contains(output, notExpected) {
+					t.Errorf("output should not contain %q, got: %q", notExpected, output)
+				}
+			}
+		})
+	}
+}
+
+func TestUntranslatedCommand_Execute_Detail_WithFixtures(t *testing.T) {
+	tests := []struct {
+		name             string
+		fixture          string
+		args             []string
+		shouldContain    []string
+		shouldNotContain []string
+	}{
+		{
+			name:          "plural variations fixture - detail for ja",
+			fixture:       "plural_variations_untranslated.xcstrings",
+			args:          []string{"--detail", "--lang", "ja"},
+			shouldContain: []string{"%lld items > ja > plural.other"},
+		},
+		{
+			name:          "substitutions fixture - detail for ja",
+			fixture:       "substitutions_untranslated.xcstrings",
+			args:          []string{"--detail", "--lang", "ja"},
+			shouldContain: []string{"%lld files in %lld folders > ja > substitutions.files.plural.other"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixturePath := filepath.Join("../fixtures", tt.fixture)
+
+			cmd := &UntranslatedCommand{}
+			flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+			cmd.SetFlags(flagSet)
+
+			args := append([]string{"-f", fixturePath}, tt.args...)
+			err := flagSet.Parse(args)
+			test.AssertNoError(t, err)
+
+			output := captureOutput(func() {
+				status := cmd.Execute(context.Background(), flagSet)
+				test.AssertEqual(t, int(status), 0)
+			})
+
+			for _, expected := range tt.shouldContain {
+				if !strings.Contains(output, expected) {
+					t.Errorf("output should contain %q, got: %q", expected, output)
+				}
+			}
+			for _, notExpected := range tt.shouldNotContain {
+				if strings.Contains(output, notExpected) {
+					t.Errorf("output should not contain %q, got: %q", notExpected, output)
+				}
+			}
+		})
+	}
+}
+
 func TestUntranslatedCommand_Execute_WithFixtures(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/fixtures/plural_variations_untranslated.xcstrings
+++ b/fixtures/plural_variations_untranslated.xcstrings
@@ -1,0 +1,56 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "%lld items": {
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld item"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld items"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": ""
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "greeting": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hello"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "こんにちは"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/fixtures/substitutions_untranslated.xcstrings
+++ b/fixtures/substitutions_untranslated.xcstrings
@@ -1,0 +1,94 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "%lld files in %lld folders": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@files@ in %#@folders@"
+          },
+          "substitutions": {
+            "files": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg file"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg files"
+                    }
+                  }
+                }
+              }
+            },
+            "folders": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg folder"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg folders"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@files@（%#@folders@内）"
+          },
+          "substitutions": {
+            "files": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "new",
+                      "value": ""
+                    }
+                  }
+                }
+              }
+            },
+            "folders": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%arg個のフォルダ"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -381,6 +381,111 @@ func (x *XCStrings) TranslatedKeys(language string) []string {
 	return translated
 }
 
+// UntranslatedDetail represents a single untranslated leaf with its path.
+type UntranslatedDetail struct {
+	Key      string
+	Language string
+	Path     string // e.g. "plural.other", "device.iphone.plural.one", "substitutions.files.plural.one"
+}
+
+// UntranslatedDetailsForLanguage returns detailed paths for all untranslated
+// leaf string units for a given language across all keys.
+func (x *XCStrings) UntranslatedDetailsForLanguage(language string) []UntranslatedDetail {
+	var details []UntranslatedDetail
+	for key, definition := range x.Strings {
+		if definition.ExtractionState == "stale" {
+			continue
+		}
+		if definition.ShouldTranslate != nil && *definition.ShouldTranslate == false {
+			continue
+		}
+		localization, exists := definition.Localizations[language]
+		if !exists {
+			details = append(details, UntranslatedDetail{Key: key, Language: language, Path: "missing"})
+			continue
+		}
+		details = append(details, localization.untranslatedPaths(key, language)...)
+	}
+	return details
+}
+
+// UntranslatedDetailsForAllLanguages returns detailed paths for all untranslated
+// leaf string units across all languages and keys.
+func (x *XCStrings) UntranslatedDetailsForAllLanguages() []UntranslatedDetail {
+	var details []UntranslatedDetail
+	languages := x.Languages()
+	for key, definition := range x.Strings {
+		if definition.ExtractionState == "stale" {
+			continue
+		}
+		if definition.ShouldTranslate != nil && *definition.ShouldTranslate == false {
+			continue
+		}
+		for _, lang := range languages {
+			localization, exists := definition.Localizations[lang]
+			if !exists {
+				details = append(details, UntranslatedDetail{Key: key, Language: lang, Path: "missing"})
+				continue
+			}
+			details = append(details, localization.untranslatedPaths(key, lang)...)
+		}
+	}
+	return details
+}
+
+// untranslatedPaths collects paths of untranslated leaf string units.
+func (l *Localization) untranslatedPaths(key, language string) []UntranslatedDetail {
+	var details []UntranslatedDetail
+	if l.StringUnit != nil {
+		if l.StringUnit.State != "translated" {
+			details = append(details, UntranslatedDetail{Key: key, Language: language, Path: l.StringUnit.State})
+		}
+	}
+	if l.Variations != nil {
+		details = append(details, l.Variations.untranslatedPaths(key, language, "")...)
+	}
+	for name, sub := range l.Substitutions {
+		details = append(details, sub.Variations.untranslatedPaths(key, language, "substitutions."+name)...)
+	}
+	return details
+}
+
+// untranslatedPaths recursively collects paths of untranslated leaf string units.
+func (v *Variations) untranslatedPaths(key, language, prefix string) []UntranslatedDetail {
+	var details []UntranslatedDetail
+	join := func(a, b string) string {
+		if a == "" {
+			return b
+		}
+		return a + "." + b
+	}
+	for cat, vv := range v.Plural {
+		if vv == nil {
+			continue
+		}
+		path := join(prefix, "plural."+cat)
+		if vv.StringUnit != nil && vv.StringUnit.State != "translated" {
+			details = append(details, UntranslatedDetail{Key: key, Language: language, Path: path})
+		}
+		if vv.Variations != nil {
+			details = append(details, vv.Variations.untranslatedPaths(key, language, path)...)
+		}
+	}
+	for dev, vv := range v.Device {
+		if vv == nil {
+			continue
+		}
+		path := join(prefix, "device."+dev)
+		if vv.StringUnit != nil && vv.StringUnit.State != "translated" {
+			details = append(details, UntranslatedDetail{Key: key, Language: language, Path: path})
+		}
+		if vv.Variations != nil {
+			details = append(details, vv.Variations.untranslatedPaths(key, language, path)...)
+		}
+	}
+	return details
+}
+
 // FilterKeysByPrefix returns keys that start with the given prefix.
 func (x *XCStrings) FilterKeysByPrefix(keys []string, prefix string) []string {
 	if prefix == "" {


### PR DESCRIPTION
## Summary
- Add --detail flag for per-variation-path untranslated reporting
- Default behavior unchanged (key-level reporting)

## Test plan
- [x] make test passes

Closes #25