### PR TITLE
feat: add --plural and --device flags to set command

### DIFF
--- a/command/set.go
+++ b/command/set.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"slices"
+
+	"xckit/xcstrings"
 
 	"github.com/google/subcommands"
 )
@@ -11,6 +15,9 @@ import (
 type SetCommand struct {
 	XCStringsCommand
 	language string
+	plural   string
+	device   string
+	force    bool
 }
 
 func (*SetCommand) Name() string {
@@ -22,12 +29,15 @@ func (*SetCommand) Synopsis() string {
 }
 
 func (*SetCommand) Usage() string {
-	return "set [-f file.xcstrings] --lang <language> <key> <value>: Set translation for a specific key and language\n"
+	return "set [-f file.xcstrings] --lang <language> [--plural <category>] [--device <device>] [--force] <key> <value>: Set translation for a specific key and language\n"
 }
 
 func (c *SetCommand) SetFlags(f *flag.FlagSet) {
 	c.SetXCStringsFlags(f)
 	f.StringVar(&c.language, "lang", "", "Target language code (e.g., ja, fr, de)")
+	f.StringVar(&c.plural, "plural", "", "Plural category (zero, one, two, few, many, other)")
+	f.StringVar(&c.device, "device", "", "Device variation (iphone, ipad, mac, appletv, applewatch, applevision, other)")
+	f.BoolVar(&c.force, "force", false, "Suppress migration warning when converting plain stringUnit to variations")
 }
 
 func (c *SetCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
@@ -43,18 +53,43 @@ func (c *SetCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		return subcommands.ExitUsageError
 	}
 
+	if c.plural != "" && !slices.Contains(xcstrings.ValidPluralCategories, c.plural) {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: invalid plural category '%s' (valid: zero, one, two, few, many, other)\n", c.plural)
+		return subcommands.ExitUsageError
+	}
+
+	if c.device != "" && !slices.Contains(xcstrings.ValidDeviceCategories, c.device) {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: invalid device '%s' (valid: iphone, ipad, mac, appletv, applewatch, applevision, other)\n", c.device)
+		return subcommands.ExitUsageError
+	}
+
 	key := f.Arg(0)
 	value := f.Arg(1)
 
-	xcstrings, err := c.LoadXCStrings()
+	xcs, err := c.LoadXCStrings()
 	if err != nil {
 		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
 		return subcommands.ExitFailure
 	}
 
-	if err := xcstrings.SetTranslation(key, c.language, value); err != nil {
-		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
-		return subcommands.ExitFailure
+	if c.plural != "" || c.device != "" {
+		opts := xcstrings.VariationOptions{
+			Plural: c.plural,
+			Device: c.device,
+		}
+		migrated, err := xcs.SetVariationTranslation(key, c.language, value, opts)
+		if err != nil {
+			fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+			return subcommands.ExitFailure
+		}
+		if migrated && !c.force {
+			fmt.Fprintf(os.Stderr, "Warning: existing plain stringUnit for key '%s' in language '%s' was migrated to variations\n", key, c.language)
+		}
+	} else {
+		if err := xcs.SetTranslation(key, c.language, value); err != nil {
+			fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+			return subcommands.ExitFailure
+		}
 	}
 
 	filePath := c.filePath
@@ -62,7 +97,7 @@ func (c *SetCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		filePath = c.findXCStringsFile()
 	}
 
-	if err := xcstrings.SaveToFile(filePath); err != nil {
+	if err := xcs.SaveToFile(filePath); err != nil {
 		fmt.Fprintf(flag.CommandLine.Output(), "Error saving file: %v\n", err)
 		return subcommands.ExitFailure
 	}

--- a/command/set_test.go
+++ b/command/set_test.go
@@ -1,14 +1,31 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"flag"
+	"os"
 	"strings"
 	"testing"
 
 	"xckit/helper/test"
 	"xckit/xcstrings"
 )
+
+func captureStderr(fn func()) string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	return buf.String()
+}
 
 func TestSetCommand_Execute(t *testing.T) {
 	testContent := `{
@@ -112,4 +129,347 @@ func TestSetCommand_Execute_FileNotFound(t *testing.T) {
 
 	status := cmd.Execute(context.Background(), flagSet)
 	test.AssertEqual(t, int(status), 1) // ExitFailure
+}
+
+func TestSetCommand_Execute_PluralVariation(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"item_count": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "%lld items"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "ja", "--plural", "other", "item_count", "%lldつのアイテム"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Successfully set translation") {
+		t.Errorf("output should contain success message, got: %q", output)
+	}
+
+	xcstringsData, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+
+	loc := xcstringsData.Strings["item_count"].Localizations["ja"]
+	if loc.Variations == nil {
+		t.Fatal("variations should exist")
+	}
+	if loc.Variations.Plural == nil {
+		t.Fatal("plural variations should exist")
+	}
+	pluralOther := loc.Variations.Plural["other"]
+	if pluralOther == nil || pluralOther.StringUnit == nil {
+		t.Fatal("plural other variation should exist")
+	}
+	test.AssertEqual(t, pluralOther.StringUnit.Value, "%lldつのアイテム")
+	test.AssertEqual(t, pluralOther.StringUnit.State, "translated")
+}
+
+func TestSetCommand_Execute_DeviceVariation(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"tap_message": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Tap here"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "ja", "--device", "ipad", "tap_message", "ここをタップ"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Successfully set translation") {
+		t.Errorf("output should contain success message, got: %q", output)
+	}
+
+	xcstringsData, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+
+	loc := xcstringsData.Strings["tap_message"].Localizations["ja"]
+	if loc.Variations == nil {
+		t.Fatal("variations should exist")
+	}
+	if loc.Variations.Device == nil {
+		t.Fatal("device variations should exist")
+	}
+	deviceIPad := loc.Variations.Device["ipad"]
+	if deviceIPad == nil || deviceIPad.StringUnit == nil {
+		t.Fatal("device ipad variation should exist")
+	}
+	test.AssertEqual(t, deviceIPad.StringUnit.Value, "ここをタップ")
+	test.AssertEqual(t, deviceIPad.StringUnit.State, "translated")
+}
+
+func TestSetCommand_Execute_PluralAndDeviceVariation(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"item_count": {
+				"localizations": {}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "ja", "--plural", "one", "--device", "iphone", "item_count", "1つのアイテム"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Successfully set translation") {
+		t.Errorf("output should contain success message, got: %q", output)
+	}
+
+	xcstringsData, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+
+	loc := xcstringsData.Strings["item_count"].Localizations["ja"]
+	if loc.Variations == nil {
+		t.Fatal("variations should exist")
+	}
+	if loc.Variations.Device == nil {
+		t.Fatal("device variations should exist")
+	}
+	deviceIPhone := loc.Variations.Device["iphone"]
+	if deviceIPhone == nil || deviceIPhone.Variations == nil {
+		t.Fatal("device iphone variation with nested variations should exist")
+	}
+	if deviceIPhone.Variations.Plural == nil {
+		t.Fatal("nested plural variations should exist")
+	}
+	pluralOne := deviceIPhone.Variations.Plural["one"]
+	if pluralOne == nil || pluralOne.StringUnit == nil {
+		t.Fatal("nested plural one variation should exist")
+	}
+	test.AssertEqual(t, pluralOne.StringUnit.Value, "1つのアイテム")
+	test.AssertEqual(t, pluralOne.StringUnit.State, "translated")
+}
+
+func TestSetCommand_Execute_MigrationWarning(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"test_key": {
+				"localizations": {
+					"ja": {"stringUnit": {"state": "translated", "value": "テスト"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "ja", "--plural", "other", "test_key", "テスト複数"})
+	test.AssertNoError(t, err)
+
+	var stderrOutput string
+	captureOutput(func() {
+		stderrOutput = captureStderr(func() {
+			status := cmd.Execute(context.Background(), flagSet)
+			test.AssertEqual(t, int(status), 0)
+		})
+	})
+
+	if !strings.Contains(stderrOutput, "Warning: existing plain stringUnit") {
+		t.Errorf("stderr should contain migration warning, got: %q", stderrOutput)
+	}
+
+	// Verify the plain stringUnit was cleared
+	xcstringsData, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+
+	loc := xcstringsData.Strings["test_key"].Localizations["ja"]
+	if loc.StringUnit != nil {
+		t.Error("plain stringUnit should have been cleared after migration")
+	}
+	if loc.Variations == nil || loc.Variations.Plural == nil {
+		t.Fatal("plural variations should exist after migration")
+	}
+}
+
+func TestSetCommand_Execute_ForceFlag(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"test_key": {
+				"localizations": {
+					"ja": {"stringUnit": {"state": "translated", "value": "テスト"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "ja", "--plural", "other", "--force", "test_key", "テスト複数"})
+	test.AssertNoError(t, err)
+
+	var stderrOutput string
+	captureOutput(func() {
+		stderrOutput = captureStderr(func() {
+			status := cmd.Execute(context.Background(), flagSet)
+			test.AssertEqual(t, int(status), 0)
+		})
+	})
+
+	if strings.Contains(stderrOutput, "Warning") {
+		t.Errorf("stderr should NOT contain migration warning with --force, got: %q", stderrOutput)
+	}
+}
+
+func TestSetCommand_Execute_InvalidPluralCategory(t *testing.T) {
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(&strings.Builder{})
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"--lang", "ja", "--plural", "invalid", "key", "value"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 2) // ExitUsageError
+}
+
+func TestSetCommand_Execute_InvalidDeviceCategory(t *testing.T) {
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(&strings.Builder{})
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"--lang", "ja", "--device", "invalid", "key", "value"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 2) // ExitUsageError
+}
+
+func TestSetCommand_Execute_NoMigrationWarningForNewLocalization(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"test_key": {
+				"localizations": {}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "ja", "--plural", "other", "test_key", "テスト"})
+	test.AssertNoError(t, err)
+
+	var stderrOutput string
+	captureOutput(func() {
+		stderrOutput = captureStderr(func() {
+			status := cmd.Execute(context.Background(), flagSet)
+			test.AssertEqual(t, int(status), 0)
+		})
+	})
+
+	if strings.Contains(stderrOutput, "Warning") {
+		t.Errorf("stderr should NOT contain migration warning for new localization, got: %q", stderrOutput)
+	}
+}
+
+func TestSetCommand_Execute_MultipleDeviceVariations(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"tap_message": {
+				"localizations": {}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	// Set first device variation
+	cmd1 := &SetCommand{}
+	flagSet1 := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd1.SetFlags(flagSet1)
+	err := flagSet1.Parse([]string{"-f", filePath, "--lang", "ja", "--device", "iphone", "tap_message", "タップ(iPhone)"})
+	test.AssertNoError(t, err)
+
+	captureOutput(func() {
+		status := cmd1.Execute(context.Background(), flagSet1)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	// Set second device variation
+	cmd2 := &SetCommand{}
+	flagSet2 := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd2.SetFlags(flagSet2)
+	err = flagSet2.Parse([]string{"-f", filePath, "--lang", "ja", "--device", "mac", "tap_message", "クリック(Mac)"})
+	test.AssertNoError(t, err)
+
+	captureOutput(func() {
+		status := cmd2.Execute(context.Background(), flagSet2)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	xcstringsData, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+
+	loc := xcstringsData.Strings["tap_message"].Localizations["ja"]
+	if loc.Variations == nil || loc.Variations.Device == nil {
+		t.Fatal("device variations should exist")
+	}
+
+	iphone := loc.Variations.Device["iphone"]
+	if iphone == nil || iphone.StringUnit == nil {
+		t.Fatal("iphone variation should exist")
+	}
+	test.AssertEqual(t, iphone.StringUnit.Value, "タップ(iPhone)")
+
+	mac := loc.Variations.Device["mac"]
+	if mac == nil || mac.StringUnit == nil {
+		t.Fatal("mac variation should exist")
+	}
+	test.AssertEqual(t, mac.StringUnit.Value, "クリック(Mac)")
 }

--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -293,6 +293,88 @@ func (x *XCStrings) SetTranslation(key, language, value string) error {
 	return nil
 }
 
+// VariationOptions specifies which variation path to set a translation on.
+type VariationOptions struct {
+	Plural string // CLDR plural category: zero, one, two, few, many, other
+	Device string // Apple device: iphone, ipad, mac, appletv, applewatch, applevision, other
+}
+
+// ValidPluralCategories contains the allowed CLDR plural categories.
+var ValidPluralCategories = []string{"zero", "one", "two", "few", "many", "other"}
+
+// ValidDeviceCategories contains the allowed Apple device identifiers.
+var ValidDeviceCategories = []string{"iphone", "ipad", "mac", "appletv", "applewatch", "applevision", "other"}
+
+// SetVariationTranslation sets a translation within a variation structure.
+// It returns (migrated bool, err error) where migrated indicates that an existing
+// plain stringUnit was converted to a variation structure.
+func (x *XCStrings) SetVariationTranslation(key, language, value string, opts VariationOptions) (bool, error) {
+	definition, exists := x.Strings[key]
+	if !exists {
+		return false, fmt.Errorf("key '%s' not found", key)
+	}
+
+	if definition.Localizations == nil {
+		definition.Localizations = make(map[string]Localization)
+	}
+
+	loc := definition.Localizations[language]
+	migrated := false
+
+	// Check if we need to migrate from plain stringUnit to variations
+	if loc.StringUnit != nil && loc.Variations == nil {
+		migrated = true
+	}
+
+	// Ensure variations structure exists
+	if loc.Variations == nil {
+		loc.Variations = &Variations{}
+	}
+
+	unit := &StringUnit{
+		State: "translated",
+		Value: value,
+	}
+
+	if opts.Plural != "" && opts.Device != "" {
+		// Both plural and device: device is the outer layer, plural is nested inside
+		if loc.Variations.Device == nil {
+			loc.Variations.Device = make(map[string]*VariationValue)
+		}
+		deviceVal := loc.Variations.Device[opts.Device]
+		if deviceVal == nil {
+			deviceVal = &VariationValue{}
+		}
+		if deviceVal.Variations == nil {
+			deviceVal.Variations = &Variations{}
+		}
+		if deviceVal.Variations.Plural == nil {
+			deviceVal.Variations.Plural = make(map[PluralCategory]*VariationValue)
+		}
+		deviceVal.Variations.Plural[opts.Plural] = &VariationValue{StringUnit: unit}
+		loc.Variations.Device[opts.Device] = deviceVal
+	} else if opts.Plural != "" {
+		if loc.Variations.Plural == nil {
+			loc.Variations.Plural = make(map[PluralCategory]*VariationValue)
+		}
+		loc.Variations.Plural[opts.Plural] = &VariationValue{StringUnit: unit}
+	} else if opts.Device != "" {
+		if loc.Variations.Device == nil {
+			loc.Variations.Device = make(map[string]*VariationValue)
+		}
+		loc.Variations.Device[opts.Device] = &VariationValue{StringUnit: unit}
+	}
+
+	// Clear plain stringUnit when migrating to variations
+	if migrated {
+		loc.StringUnit = nil
+	}
+
+	definition.Localizations[language] = loc
+	x.Strings[key] = definition
+	return migrated, nil
+}
+
 // KeysWithAnyUntranslated returns keys that have at least one untranslated language.
 // A language is considered untranslated if any leaf StringUnit (including within
 // variations and substitutions) does not have the "translated" state.


### PR DESCRIPTION
## Summary
- Add --plural flag for CLDR plural categories (zero, one, two, few, many, other)
- Add --device flag for Apple device identifiers (iphone, ipad, mac, appletv, applewatch, applevision, other)
- Auto-create variation structure when needed, including nested device+plural combinations
- Migration warning to stderr when converting plain stringUnit to variations
- --force flag to suppress migration warning

## Test plan
- [x] make test passes

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)