### PR TITLE
feat: add CSV export command

### DIFF
--- a/command/export.go
+++ b/command/export.go
@@ -1,0 +1,356 @@
+package command
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/google/subcommands"
+	"xckit/xcstrings"
+)
+
+type ExportCommand struct {
+	XCStringsCommand
+	format string
+	output string
+}
+
+func (*ExportCommand) Name() string {
+	return "export"
+}
+
+func (*ExportCommand) Synopsis() string {
+	return "Export strings to CSV"
+}
+
+func (*ExportCommand) Usage() string {
+	return "export --format csv [-f file.xcstrings] [-o output.csv]: Export strings to CSV\n"
+}
+
+func (c *ExportCommand) SetFlags(f *flag.FlagSet) {
+	c.SetXCStringsFlags(f)
+	f.StringVar(&c.format, "format", "", "Export format (csv)")
+	f.StringVar(&c.output, "o", "", "Output file path (default: stdout)")
+}
+
+func (c *ExportCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	if c.format != "csv" {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: --format csv is required\n")
+		return subcommands.ExitFailure
+	}
+
+	xc, err := c.LoadXCStrings()
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	var w io.Writer
+	if c.output != "" {
+		file, err := os.Create(c.output)
+		if err != nil {
+			fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+			return subcommands.ExitFailure
+		}
+		defer file.Close()
+		w = file
+	} else {
+		w = os.Stdout
+	}
+
+	if err := writeCSV(w, xc); err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	return subcommands.ExitSuccess
+}
+
+// csvRow represents a single row in the CSV output.
+type csvRow struct {
+	key             string
+	comment         string
+	shouldTranslate string
+	// langData maps language code to [state, value].
+	langData map[string][2]string
+}
+
+// writeCSV writes the xcstrings data as CSV to the given writer.
+func writeCSV(w io.Writer, xc *xcstrings.XCStrings) error {
+	langs := buildLanguageOrder(xc)
+	rows := buildRows(xc, langs)
+
+	writer := csv.NewWriter(w)
+	defer writer.Flush()
+
+	// Write header
+	header := []string{"key", "comment", "shouldTranslate"}
+	for _, lang := range langs {
+		header = append(header, lang+":state", lang)
+	}
+	if err := writer.Write(header); err != nil {
+		return err
+	}
+
+	// Write data rows
+	for _, row := range rows {
+		record := []string{row.key, row.comment, row.shouldTranslate}
+		for _, lang := range langs {
+			if data, ok := row.langData[lang]; ok {
+				record = append(record, data[0], data[1])
+			} else {
+				record = append(record, "", "")
+			}
+		}
+		if err := writer.Write(record); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// buildLanguageOrder returns languages with source language first, then others alphabetically.
+func buildLanguageOrder(xc *xcstrings.XCStrings) []string {
+	langSet := make(map[string]bool)
+	for _, def := range xc.Strings {
+		for lang := range def.Localizations {
+			langSet[lang] = true
+		}
+	}
+
+	var others []string
+	for lang := range langSet {
+		if lang != xc.SourceLanguage {
+			others = append(others, lang)
+		}
+	}
+	sort.Strings(others)
+
+	langs := []string{xc.SourceLanguage}
+	langs = append(langs, others...)
+	return langs
+}
+
+// buildRows flattens xcstrings into CSV rows, expanding variations.
+func buildRows(xc *xcstrings.XCStrings, langs []string) []csvRow {
+	keys := make([]string, 0, len(xc.Strings))
+	for k := range xc.Strings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var rows []csvRow
+	for _, key := range keys {
+		def := xc.Strings[key]
+		rows = append(rows, flattenKey(key, def, langs)...)
+	}
+	return rows
+}
+
+// flattenKey produces one or more csvRows for a key, expanding variations.
+func flattenKey(key string, def xcstrings.StringDefinition, langs []string) []csvRow {
+	comment := def.Comment
+	shouldTranslate := ""
+	if def.ShouldTranslate != nil && !*def.ShouldTranslate {
+		shouldTranslate = "false"
+	}
+
+	// Determine the variation structure from the first language that has localizations.
+	// We need to collect all variation suffixes across all languages.
+	suffixes := collectVariationSuffixes(def, langs)
+
+	if len(suffixes) == 0 {
+		// Simple string, no variations
+		row := csvRow{
+			key:             key,
+			comment:         comment,
+			shouldTranslate: shouldTranslate,
+			langData:        make(map[string][2]string),
+		}
+		for _, lang := range langs {
+			loc, ok := def.Localizations[lang]
+			if !ok {
+				continue
+			}
+			if loc.StringUnit != nil {
+				row.langData[lang] = [2]string{loc.StringUnit.State, loc.StringUnit.Value}
+			}
+		}
+		return []csvRow{row}
+	}
+
+	// For keys with variations, produce one row per suffix.
+	// Sort suffixes for deterministic output.
+	sort.Strings(suffixes)
+
+	var rows []csvRow
+	for _, suffix := range suffixes {
+		row := csvRow{
+			key:             key + "[" + suffix + "]",
+			comment:         comment,
+			shouldTranslate: shouldTranslate,
+			langData:        make(map[string][2]string),
+		}
+		// Only put comment on the first row
+		if len(rows) > 0 {
+			row.comment = ""
+		}
+		for _, lang := range langs {
+			loc, ok := def.Localizations[lang]
+			if !ok {
+				continue
+			}
+			unit := resolveVariationUnit(loc, suffix)
+			if unit != nil {
+				row.langData[lang] = [2]string{unit.State, unit.Value}
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// collectVariationSuffixes gathers all unique variation path suffixes across all languages.
+func collectVariationSuffixes(def xcstrings.StringDefinition, langs []string) []string {
+	suffixSet := make(map[string]bool)
+	for _, lang := range langs {
+		loc, ok := def.Localizations[lang]
+		if !ok {
+			continue
+		}
+		if loc.Variations != nil {
+			collectVariationPaths(loc.Variations, "", suffixSet)
+		}
+		for subName, sub := range loc.Substitutions {
+			collectVariationPaths(&sub.Variations, "substitutions."+subName, suffixSet)
+		}
+	}
+
+	suffixes := make([]string, 0, len(suffixSet))
+	for s := range suffixSet {
+		suffixes = append(suffixes, s)
+	}
+	return suffixes
+}
+
+// collectVariationPaths recursively collects leaf paths from Variations.
+func collectVariationPaths(v *xcstrings.Variations, prefix string, out map[string]bool) {
+	join := func(a, b string) string {
+		if a == "" {
+			return b
+		}
+		return a + "." + b
+	}
+	for cat, vv := range v.Plural {
+		if vv == nil {
+			continue
+		}
+		path := join(prefix, "plural."+cat)
+		if vv.StringUnit != nil {
+			out[path] = true
+		}
+		if vv.Variations != nil {
+			collectVariationPaths(vv.Variations, path, out)
+		}
+	}
+	for dev, vv := range v.Device {
+		if vv == nil {
+			continue
+		}
+		path := join(prefix, "device."+dev)
+		if vv.StringUnit != nil {
+			out[path] = true
+		}
+		if vv.Variations != nil {
+			collectVariationPaths(vv.Variations, path, out)
+		}
+	}
+}
+
+// resolveVariationUnit finds the StringUnit for a given variation suffix path
+// within a localization.
+func resolveVariationUnit(loc xcstrings.Localization, suffix string) *xcstrings.StringUnit {
+	// Parse the suffix path and navigate through the localization structure.
+	// Examples: "plural.one", "device.iphone", "device.iphone.plural.one",
+	// "substitutions.files.plural.one"
+	parts := splitPath(suffix)
+	if len(parts) == 0 {
+		return nil
+	}
+
+	// Handle substitutions prefix
+	if parts[0] == "substitutions" && len(parts) >= 2 {
+		subName := parts[1]
+		sub, ok := loc.Substitutions[subName]
+		if !ok {
+			return nil
+		}
+		return navigateVariations(&sub.Variations, parts[2:])
+	}
+
+	// Handle top-level variations
+	if loc.Variations == nil {
+		return nil
+	}
+	return navigateVariations(loc.Variations, parts)
+}
+
+// navigateVariations walks a Variations tree following the given path segments.
+func navigateVariations(v *xcstrings.Variations, parts []string) *xcstrings.StringUnit {
+	if len(parts) < 2 {
+		return nil
+	}
+
+	varType := parts[0] // "plural" or "device"
+	varKey := parts[1]
+	remaining := parts[2:]
+
+	var vv *xcstrings.VariationValue
+	switch varType {
+	case "plural":
+		if v.Plural != nil {
+			vv = v.Plural[varKey]
+		}
+	case "device":
+		if v.Device != nil {
+			vv = v.Device[varKey]
+		}
+	default:
+		return nil
+	}
+
+	if vv == nil {
+		return nil
+	}
+
+	if len(remaining) == 0 {
+		return vv.StringUnit
+	}
+
+	if vv.Variations != nil {
+		return navigateVariations(vv.Variations, remaining)
+	}
+	return nil
+}
+
+// splitPath splits a dot-separated path into segments.
+func splitPath(path string) []string {
+	if path == "" {
+		return nil
+	}
+	var parts []string
+	start := 0
+	for i := 0; i < len(path); i++ {
+		if path[i] == '.' {
+			parts = append(parts, path[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, path[start:])
+	return parts
+}

--- a/command/export_test.go
+++ b/command/export_test.go
@@ -1,0 +1,546 @@
+package command
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"xckit/helper/test"
+	"xckit/xcstrings"
+)
+
+func TestExportCommand_Execute_SimpleCSV(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"comment": "A greeting",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+					"ja": {"stringUnit": {"state": "translated", "value": "こんにちは"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (header + 1 row), got %d: %q", len(lines), output)
+	}
+	test.AssertEqual(t, lines[0], "key,comment,shouldTranslate,en:state,en,ja:state,ja")
+	test.AssertEqual(t, lines[1], "greeting,A greeting,,translated,Hello,translated,こんにちは")
+}
+
+func TestExportCommand_Execute_PluralVariations(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"item_count": {
+				"localizations": {
+					"en": {
+						"variations": {
+							"plural": {
+								"one": {"stringUnit": {"state": "translated", "value": "%lld item"}},
+								"other": {"stringUnit": {"state": "translated", "value": "%lld items"}}
+							}
+						}
+					},
+					"ja": {
+						"variations": {
+							"plural": {
+								"other": {"stringUnit": {"state": "translated", "value": "%lld個"}}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), output)
+	}
+	test.AssertEqual(t, lines[0], "key,comment,shouldTranslate,en:state,en,ja:state,ja")
+	test.AssertEqual(t, lines[1], "item_count[plural.one],,,translated,%lld item,,")
+	test.AssertEqual(t, lines[2], "item_count[plural.other],,,translated,%lld items,translated,%lld個")
+}
+
+func TestExportCommand_Execute_DeviceVariations(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"welcome": {
+				"localizations": {
+					"en": {
+						"variations": {
+							"device": {
+								"ipad": {"stringUnit": {"state": "translated", "value": "Welcome iPad"}},
+								"iphone": {"stringUnit": {"state": "translated", "value": "Welcome iPhone"}}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), output)
+	}
+	test.AssertEqual(t, lines[0], "key,comment,shouldTranslate,en:state,en")
+	test.AssertEqual(t, lines[1], "welcome[device.ipad],,,translated,Welcome iPad")
+	test.AssertEqual(t, lines[2], "welcome[device.iphone],,,translated,Welcome iPhone")
+}
+
+func TestExportCommand_Execute_NestedVariations(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"photos": {
+				"localizations": {
+					"en": {
+						"variations": {
+							"device": {
+								"iphone": {
+									"variations": {
+										"plural": {
+											"one": {"stringUnit": {"state": "translated", "value": "%lld photo on iPhone"}},
+											"other": {"stringUnit": {"state": "translated", "value": "%lld photos on iPhone"}}
+										}
+									}
+								},
+								"other": {
+									"variations": {
+										"plural": {
+											"one": {"stringUnit": {"state": "translated", "value": "%lld photo"}},
+											"other": {"stringUnit": {"state": "translated", "value": "%lld photos"}}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 lines, got %d: %q", len(lines), output)
+	}
+	test.AssertEqual(t, lines[0], "key,comment,shouldTranslate,en:state,en")
+
+	// Sorted: device.iphone.plural.one, device.iphone.plural.other, device.other.plural.one, device.other.plural.other
+	if !strings.Contains(output, "photos[device.iphone.plural.one]") {
+		t.Errorf("output should contain nested variation key, got: %q", output)
+	}
+	if !strings.Contains(output, "%lld photo on iPhone") {
+		t.Errorf("output should contain nested variation value, got: %q", output)
+	}
+}
+
+func TestExportCommand_Execute_Substitutions(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"file_summary": {
+				"localizations": {
+					"en": {
+						"stringUnit": {"state": "translated", "value": "%#@files@ in %#@folders@"},
+						"substitutions": {
+							"files": {
+								"argNum": 1,
+								"formatSpecifier": "lld",
+								"variations": {
+									"plural": {
+										"one": {"stringUnit": {"state": "translated", "value": "%arg file"}},
+										"other": {"stringUnit": {"state": "translated", "value": "%arg files"}}
+									}
+								}
+							},
+							"folders": {
+								"argNum": 2,
+								"formatSpecifier": "lld",
+								"variations": {
+									"plural": {
+										"one": {"stringUnit": {"state": "translated", "value": "%arg folder"}},
+										"other": {"stringUnit": {"state": "translated", "value": "%arg folders"}}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	expectedSubstrings := []string{
+		"file_summary[substitutions.files.plural.one]",
+		"file_summary[substitutions.files.plural.other]",
+		"file_summary[substitutions.folders.plural.one]",
+		"file_summary[substitutions.folders.plural.other]",
+		"%arg file",
+		"%arg files",
+		"%arg folder",
+		"%arg folders",
+	}
+	for _, expected := range expectedSubstrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output should contain %q, got: %q", expected, output)
+		}
+	}
+}
+
+func TestExportCommand_Execute_OutputFile(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"hello": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+	outPath := filepath.Join(t.TempDir(), "output.csv")
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv", "-o", outPath})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 0)
+
+	data, err := os.ReadFile(outPath)
+	test.AssertNoError(t, err)
+
+	output := string(data)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), output)
+	}
+	test.AssertEqual(t, lines[0], "key,comment,shouldTranslate,en:state,en")
+	test.AssertEqual(t, lines[1], "hello,,,translated,Hello")
+}
+
+func TestExportCommand_Execute_MissingFormat(t *testing.T) {
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 1)
+}
+
+func TestExportCommand_Execute_FileNotFound(t *testing.T) {
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(&strings.Builder{})
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", "nonexistent.xcstrings", "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 1)
+}
+
+func TestExportCommand_Execute_ShouldTranslateFalse(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"app_name": {
+				"shouldTranslate": false,
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "MyApp"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "false") {
+		t.Errorf("output should contain shouldTranslate=false, got: %q", output)
+	}
+}
+
+func TestExportCommand_Execute_LanguageOrder(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"hello": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+					"zh": {"stringUnit": {"state": "translated", "value": "你好"}},
+					"ja": {"stringUnit": {"state": "translated", "value": "こんにちは"}},
+					"es": {"stringUnit": {"state": "translated", "value": "Hola"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// Source language (en) first, then es, ja, zh alphabetically
+	test.AssertEqual(t, lines[0], "key,comment,shouldTranslate,en:state,en,es:state,es,ja:state,ja,zh:state,zh")
+}
+
+func TestExportCommand_Execute_CSVQuoting(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"msg": {
+				"comment": "Has, comma",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello, World"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	// encoding/csv should quote fields with commas
+	if !strings.Contains(output, `"Has, comma"`) {
+		t.Errorf("expected quoted comment field, got: %q", output)
+	}
+	if !strings.Contains(output, `"Hello, World"`) {
+		t.Errorf("expected quoted value field, got: %q", output)
+	}
+}
+
+func TestExportCommand_Execute_MultipleKeysSorted(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"zebra": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Zebra"}}
+				}
+			},
+			"apple": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Apple"}}
+				}
+			},
+			"mango": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Mango"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines, got %d", len(lines))
+	}
+	if !strings.HasPrefix(lines[1], "apple,") {
+		t.Errorf("first data row should be apple, got: %q", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "mango,") {
+		t.Errorf("second data row should be mango, got: %q", lines[2])
+	}
+	if !strings.HasPrefix(lines[3], "zebra,") {
+		t.Errorf("third data row should be zebra, got: %q", lines[3])
+	}
+}
+
+func TestWriteCSV_Unit(t *testing.T) {
+	boolFalse := false
+	xc := &xcstrings.XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]xcstrings.StringDefinition{
+			"greeting": {
+				Comment: "A greeting",
+				Localizations: map[string]xcstrings.Localization{
+					"en": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Hello"}},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "こんにちは"}},
+				},
+			},
+			"no_translate": {
+				ShouldTranslate: &boolFalse,
+				Localizations: map[string]xcstrings.Localization{
+					"en": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "AppName"}},
+				},
+			},
+		},
+		Version: "1.0",
+	}
+
+	var buf bytes.Buffer
+	err := writeCSV(&buf, xc)
+	test.AssertNoError(t, err)
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), output)
+	}
+	test.AssertEqual(t, lines[0], "key,comment,shouldTranslate,en:state,en,ja:state,ja")
+	test.AssertEqual(t, lines[1], "greeting,A greeting,,translated,Hello,translated,こんにちは")
+	test.AssertEqual(t, lines[2], "no_translate,,false,translated,AppName,,")
+}
+
+func TestExportCommand_Execute_EmptyStrings(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &ExportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// Only header row
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line (header only), got %d: %q", len(lines), output)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 func main() {
+	subcommands.Register(&command.ExportCommand{}, "")
 	subcommands.Register(&command.UntranslatedCommand{}, "")
 	subcommands.Register(&command.ListCommand{}, "")
 	subcommands.Register(&command.SetCommand{}, "")


### PR DESCRIPTION
## Summary
- Add export command with --format csv
- Flattens xcstrings to CSV with variation key suffixes
- Supports plural, device, nested, and substitution variations

## Test plan
- [x] make test passes

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)