### PR TITLE
feat: add CSV import command

### DIFF
--- a/command/import.go
+++ b/command/import.go
@@ -1,0 +1,435 @@
+package command
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/google/subcommands"
+	"xckit/xcstrings"
+)
+
+type ImportCommand struct {
+	XCStringsCommand
+	format       string
+	dryRun       bool
+	backup       bool
+	onMissingKey string
+	clearEmpty   bool
+}
+
+func (*ImportCommand) Name() string {
+	return "import"
+}
+
+func (*ImportCommand) Synopsis() string {
+	return "Import translations from CSV"
+}
+
+func (*ImportCommand) Usage() string {
+	return "import --format csv [-f file.xcstrings] [--dry-run] [--backup] [--on-missing-key skip|error] [--clear-empty] <csv-file>: Import translations from CSV\n"
+}
+
+func (c *ImportCommand) SetFlags(f *flag.FlagSet) {
+	c.SetXCStringsFlags(f)
+	f.StringVar(&c.format, "format", "", "Import format (csv)")
+	f.BoolVar(&c.dryRun, "dry-run", false, "Show change summary without writing")
+	f.BoolVar(&c.backup, "backup", false, "Copy original to .bak before writing")
+	f.StringVar(&c.onMissingKey, "on-missing-key", "skip", "Action for missing keys: skip or error")
+	f.BoolVar(&c.clearEmpty, "clear-empty", false, "Clear translations for empty CSV cells")
+}
+
+func (c *ImportCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	if c.format != "csv" {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: --format csv is required\n")
+		return subcommands.ExitFailure
+	}
+
+	if c.onMissingKey != "skip" && c.onMissingKey != "error" {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: --on-missing-key must be skip or error\n")
+		return subcommands.ExitFailure
+	}
+
+	args := f.Args()
+	if len(args) < 1 {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: CSV file path is required\n")
+		return subcommands.ExitFailure
+	}
+	csvPath := args[0]
+
+	xc, err := c.LoadXCStrings()
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	csvFile, err := os.Open(csvPath)
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+	defer csvFile.Close()
+
+	summary, err := importCSV(csvFile, xc, c.onMissingKey, c.clearEmpty)
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	if c.dryRun {
+		fmt.Fprintf(os.Stdout, "Dry run: %d updated, %d skipped, %d cleared\n", summary.updated, summary.skipped, summary.cleared)
+		return subcommands.ExitSuccess
+	}
+
+	xcPath := c.filePath
+	if xcPath == "" {
+		xcPath = c.findXCStringsFile()
+	}
+
+	if c.backup {
+		if xcPath != "" {
+			data, err := os.ReadFile(xcPath)
+			if err != nil {
+				fmt.Fprintf(flag.CommandLine.Output(), "Error creating backup: %v\n", err)
+				return subcommands.ExitFailure
+			}
+			if err := os.WriteFile(xcPath+".bak", data, 0644); err != nil {
+				fmt.Fprintf(flag.CommandLine.Output(), "Error creating backup: %v\n", err)
+				return subcommands.ExitFailure
+			}
+		}
+	}
+	if err := xc.SaveToFile(xcPath); err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	fmt.Fprintf(os.Stdout, "Imported: %d updated, %d skipped, %d cleared\n", summary.updated, summary.skipped, summary.cleared)
+	return subcommands.ExitSuccess
+}
+
+type importSummary struct {
+	updated int
+	skipped int
+	cleared int
+}
+
+// importCSV reads CSV data and applies translations to the xcstrings catalog.
+func importCSV(r io.Reader, xc *xcstrings.XCStrings, onMissingKey string, clearEmpty bool) (*importSummary, error) {
+	reader := csv.NewReader(r)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CSV: %w", err)
+	}
+
+	if len(records) < 1 {
+		return &importSummary{}, nil
+	}
+
+	header := records[0]
+	langColumns, err := parseHeader(header)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &importSummary{}
+
+	for _, record := range records[1:] {
+		if len(record) < 1 {
+			continue
+		}
+		rawKey := record[0]
+		// column 1 = comment (ignored)
+		// column 2 = shouldTranslate (ignored)
+
+		baseKey, variationPath := parseKeyBracket(rawKey)
+
+		_, keyExists := xc.Strings[baseKey]
+		if !keyExists {
+			if onMissingKey == "error" {
+				return nil, fmt.Errorf("key not found: %s", baseKey)
+			}
+			summary.skipped++
+			continue
+		}
+
+		for _, lc := range langColumns {
+			// Skip source language
+			if lc.lang == xc.SourceLanguage {
+				continue
+			}
+
+			if lc.valueIdx >= len(record) {
+				continue
+			}
+			value := record[lc.valueIdx]
+
+			if value == "" {
+				if clearEmpty {
+					if err := clearTranslation(xc, baseKey, lc.lang, variationPath); err == nil {
+						summary.cleared++
+					}
+				}
+				continue
+			}
+
+			if err := setTranslation(xc, baseKey, lc.lang, value, variationPath); err != nil {
+				return nil, fmt.Errorf("failed to set translation for key %q lang %q: %w", baseKey, lc.lang, err)
+			}
+			summary.updated++
+		}
+	}
+
+	return summary, nil
+}
+
+// langColumn represents a language column pair in the CSV header.
+type langColumn struct {
+	lang      string
+	stateIdx  int // index of {lang}:state column
+	valueIdx  int // index of {lang} value column
+}
+
+// parseHeader parses the CSV header to find language columns.
+// Expected format: key, comment, shouldTranslate, {lang}:state, {lang}, ...
+func parseHeader(header []string) ([]langColumn, error) {
+	if len(header) < 3 {
+		return nil, fmt.Errorf("CSV header must have at least 3 columns (key, comment, shouldTranslate)")
+	}
+
+	var cols []langColumn
+	i := 3 // skip key, comment, shouldTranslate
+	for i < len(header) {
+		col := header[i]
+		if strings.HasSuffix(col, ":state") {
+			lang := strings.TrimSuffix(col, ":state")
+			if i+1 < len(header) && header[i+1] == lang {
+				cols = append(cols, langColumn{
+					lang:     lang,
+					stateIdx: i,
+					valueIdx: i + 1,
+				})
+				i += 2
+				continue
+			}
+		}
+		i++
+	}
+
+	return cols, nil
+}
+
+// parseKeyBracket splits "key[suffix]" into (key, suffix).
+// If no brackets, returns (key, "").
+func parseKeyBracket(raw string) (string, string) {
+	idx := strings.Index(raw, "[")
+	if idx < 0 {
+		return raw, ""
+	}
+	end := strings.LastIndex(raw, "]")
+	if end <= idx {
+		return raw, ""
+	}
+	return raw[:idx], raw[idx+1 : end]
+}
+
+// setTranslation sets a translation value, handling both simple and variation keys.
+func setTranslation(xc *xcstrings.XCStrings, key, lang, value, variationPath string) error {
+	if variationPath == "" {
+		return xc.SetTranslation(key, lang, value)
+	}
+
+	parts := splitPath(variationPath)
+
+	// Handle substitutions
+	if len(parts) >= 2 && parts[0] == "substitutions" {
+		return setSubstitutionTranslation(xc, key, lang, value, parts[1], parts[2:])
+	}
+
+	// Handle plural/device variations
+	opts := parseVariationOpts(parts)
+	_, err := xc.SetVariationTranslation(key, lang, value, opts)
+	return err
+}
+
+// clearTranslation clears a translation for a key/lang/variation path.
+func clearTranslation(xc *xcstrings.XCStrings, key, lang, variationPath string) error {
+	def, exists := xc.Strings[key]
+	if !exists {
+		return fmt.Errorf("key not found: %s", key)
+	}
+
+	loc, exists := def.Localizations[lang]
+	if !exists {
+		return nil // nothing to clear
+	}
+
+	if variationPath == "" {
+		if loc.StringUnit != nil {
+			loc.StringUnit = nil
+			def.Localizations[lang] = loc
+			xc.Strings[key] = def
+		}
+		return nil
+	}
+
+	parts := splitPath(variationPath)
+
+	if len(parts) >= 2 && parts[0] == "substitutions" {
+		return clearSubstitutionVariation(&loc, &def, xc, key, lang, parts[1], parts[2:])
+	}
+
+	clearVariationUnit(loc.Variations, parts)
+	def.Localizations[lang] = loc
+	xc.Strings[key] = def
+	return nil
+}
+
+// clearVariationUnit navigates and clears a variation leaf.
+func clearVariationUnit(v *xcstrings.Variations, parts []string) {
+	if v == nil || len(parts) < 2 {
+		return
+	}
+	varType := parts[0]
+	varKey := parts[1]
+	remaining := parts[2:]
+
+	switch varType {
+	case "plural":
+		if v.Plural == nil {
+			return
+		}
+		vv := v.Plural[varKey]
+		if vv == nil {
+			return
+		}
+		if len(remaining) == 0 {
+			vv.StringUnit = nil
+		} else if vv.Variations != nil {
+			clearVariationUnit(vv.Variations, remaining)
+		}
+	case "device":
+		if v.Device == nil {
+			return
+		}
+		vv := v.Device[varKey]
+		if vv == nil {
+			return
+		}
+		if len(remaining) == 0 {
+			vv.StringUnit = nil
+		} else if vv.Variations != nil {
+			clearVariationUnit(vv.Variations, remaining)
+		}
+	}
+}
+
+// clearSubstitutionVariation clears a substitution variation leaf.
+func clearSubstitutionVariation(loc *xcstrings.Localization, def *xcstrings.StringDefinition, xc *xcstrings.XCStrings, key, lang, subName string, parts []string) error {
+	sub, ok := loc.Substitutions[subName]
+	if !ok {
+		return nil
+	}
+	clearVariationUnit(&sub.Variations, parts)
+	loc.Substitutions[subName] = sub
+	def.Localizations[lang] = *loc
+	xc.Strings[key] = *def
+	return nil
+}
+
+// setSubstitutionTranslation sets a translation within a substitution variation.
+func setSubstitutionTranslation(xc *xcstrings.XCStrings, key, lang, value, subName string, parts []string) error {
+	def, exists := xc.Strings[key]
+	if !exists {
+		return fmt.Errorf("key '%s' not found", key)
+	}
+
+	if def.Localizations == nil {
+		def.Localizations = make(map[string]xcstrings.Localization)
+	}
+
+	loc := def.Localizations[lang]
+	if loc.Substitutions == nil {
+		loc.Substitutions = make(map[string]xcstrings.Substitution)
+	}
+
+	sub := loc.Substitutions[subName]
+
+	unit := &xcstrings.StringUnit{
+		State: "translated",
+		Value: value,
+	}
+
+	setVariationUnit(&sub.Variations, parts, unit)
+
+	loc.Substitutions[subName] = sub
+	def.Localizations[lang] = loc
+	xc.Strings[key] = def
+	return nil
+}
+
+// setVariationUnit navigates and sets a variation leaf.
+func setVariationUnit(v *xcstrings.Variations, parts []string, unit *xcstrings.StringUnit) {
+	if len(parts) < 2 {
+		return
+	}
+	varType := parts[0]
+	varKey := parts[1]
+	remaining := parts[2:]
+
+	switch varType {
+	case "plural":
+		if v.Plural == nil {
+			v.Plural = make(map[xcstrings.PluralCategory]*xcstrings.VariationValue)
+		}
+		if len(remaining) == 0 {
+			v.Plural[varKey] = &xcstrings.VariationValue{StringUnit: unit}
+		} else {
+			vv := v.Plural[varKey]
+			if vv == nil {
+				vv = &xcstrings.VariationValue{}
+			}
+			if vv.Variations == nil {
+				vv.Variations = &xcstrings.Variations{}
+			}
+			setVariationUnit(vv.Variations, remaining, unit)
+			v.Plural[varKey] = vv
+		}
+	case "device":
+		if v.Device == nil {
+			v.Device = make(map[string]*xcstrings.VariationValue)
+		}
+		if len(remaining) == 0 {
+			v.Device[varKey] = &xcstrings.VariationValue{StringUnit: unit}
+		} else {
+			vv := v.Device[varKey]
+			if vv == nil {
+				vv = &xcstrings.VariationValue{}
+			}
+			if vv.Variations == nil {
+				vv.Variations = &xcstrings.Variations{}
+			}
+			setVariationUnit(vv.Variations, remaining, unit)
+			v.Device[varKey] = vv
+		}
+	}
+}
+
+// parseVariationOpts converts path parts to VariationOptions.
+// Supports: plural.X, device.X, device.X.plural.Y
+func parseVariationOpts(parts []string) xcstrings.VariationOptions {
+	opts := xcstrings.VariationOptions{}
+	for i := 0; i < len(parts)-1; i += 2 {
+		switch parts[i] {
+		case "plural":
+			opts.Plural = parts[i+1]
+		case "device":
+			opts.Device = parts[i+1]
+		}
+	}
+	return opts
+}

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -1,0 +1,670 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"xckit/helper/test"
+	"xckit/xcstrings"
+)
+
+func TestImportCommand_Execute_SimpleCSV(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+					"ja": {"stringUnit": {"state": "needs_review", "value": ""}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\ngreeting,A greeting,,translated,Hello,translated,こんにちは\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "1 updated") {
+		t.Errorf("expected 1 updated, got: %q", output)
+	}
+
+	// Verify the file was updated
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+
+	loc := xc.Strings["greeting"].Localizations["ja"]
+	test.AssertEqual(t, loc.StringUnit.Value, "こんにちは")
+	test.AssertEqual(t, loc.StringUnit.State, "translated")
+}
+
+func TestImportCommand_Execute_PluralVariations(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"item_count": {
+				"localizations": {
+					"en": {
+						"variations": {
+							"plural": {
+								"one": {"stringUnit": {"state": "translated", "value": "%lld item"}},
+								"other": {"stringUnit": {"state": "translated", "value": "%lld items"}}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\nitem_count[plural.one],,,translated,%lld item,,1個のアイテム\nitem_count[plural.other],,,translated,%lld items,,アイテム\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "2 updated") {
+		t.Errorf("expected 2 updated, got: %q", output)
+	}
+
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+
+	loc := xc.Strings["item_count"].Localizations["ja"]
+	if loc.Variations == nil || loc.Variations.Plural == nil {
+		t.Fatal("expected plural variations for ja")
+	}
+	test.AssertEqual(t, loc.Variations.Plural["one"].StringUnit.Value, "1個のアイテム")
+	test.AssertEqual(t, loc.Variations.Plural["other"].StringUnit.Value, "アイテム")
+}
+
+func TestImportCommand_Execute_DeviceVariations(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"welcome": {
+				"localizations": {
+					"en": {
+						"variations": {
+							"device": {
+								"ipad": {"stringUnit": {"state": "translated", "value": "Welcome iPad"}},
+								"iphone": {"stringUnit": {"state": "translated", "value": "Welcome iPhone"}}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\nwelcome[device.ipad],,,translated,Welcome iPad,,iPadへようこそ\nwelcome[device.iphone],,,translated,Welcome iPhone,,iPhoneへようこそ\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "2 updated") {
+		t.Errorf("expected 2 updated, got: %q", output)
+	}
+
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+
+	loc := xc.Strings["welcome"].Localizations["ja"]
+	if loc.Variations == nil || loc.Variations.Device == nil {
+		t.Fatal("expected device variations for ja")
+	}
+	test.AssertEqual(t, loc.Variations.Device["ipad"].StringUnit.Value, "iPadへようこそ")
+	test.AssertEqual(t, loc.Variations.Device["iphone"].StringUnit.Value, "iPhoneへようこそ")
+}
+
+func TestImportCommand_Execute_NestedVariations(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"photos": {
+				"localizations": {
+					"en": {
+						"variations": {
+							"device": {
+								"iphone": {
+									"variations": {
+										"plural": {
+											"one": {"stringUnit": {"state": "translated", "value": "%lld photo on iPhone"}},
+											"other": {"stringUnit": {"state": "translated", "value": "%lld photos on iPhone"}}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\nphotos[device.iphone.plural.one],,,translated,%lld photo on iPhone,,iPhoneの写真%lld枚\nphotos[device.iphone.plural.other],,,translated,%lld photos on iPhone,,iPhoneの写真%lld枚\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "2 updated") {
+		t.Errorf("expected 2 updated, got: %q", output)
+	}
+
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+
+	loc := xc.Strings["photos"].Localizations["ja"]
+	if loc.Variations == nil || loc.Variations.Device == nil {
+		t.Fatal("expected device variations for ja")
+	}
+	dv := loc.Variations.Device["iphone"]
+	if dv == nil || dv.Variations == nil || dv.Variations.Plural == nil {
+		t.Fatal("expected nested plural variations under device.iphone for ja")
+	}
+	test.AssertEqual(t, dv.Variations.Plural["one"].StringUnit.Value, "iPhoneの写真%lld枚")
+}
+
+func TestImportCommand_Execute_Substitutions(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"file_summary": {
+				"localizations": {
+					"en": {
+						"stringUnit": {"state": "translated", "value": "%#@files@ in %#@folders@"},
+						"substitutions": {
+							"files": {
+								"argNum": 1,
+								"formatSpecifier": "lld",
+								"variations": {
+									"plural": {
+										"one": {"stringUnit": {"state": "translated", "value": "%arg file"}},
+										"other": {"stringUnit": {"state": "translated", "value": "%arg files"}}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\nfile_summary[substitutions.files.plural.one],,,translated,%arg file,,ファイル%arg個\nfile_summary[substitutions.files.plural.other],,,translated,%arg files,,ファイル%arg個\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "2 updated") {
+		t.Errorf("expected 2 updated, got: %q", output)
+	}
+
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+
+	loc := xc.Strings["file_summary"].Localizations["ja"]
+	if loc.Substitutions == nil {
+		t.Fatal("expected substitutions for ja")
+	}
+	sub := loc.Substitutions["files"]
+	if sub.Variations.Plural == nil {
+		t.Fatal("expected plural variations in files substitution")
+	}
+	test.AssertEqual(t, sub.Variations.Plural["one"].StringUnit.Value, "ファイル%arg個")
+	test.AssertEqual(t, sub.Variations.Plural["other"].StringUnit.Value, "ファイル%arg個")
+}
+
+func TestImportCommand_Execute_DryRun(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\ngreeting,,,translated,Hello,,こんにちは\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", "--dry-run", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Dry run") {
+		t.Errorf("expected dry run output, got: %q", output)
+	}
+
+	// Verify file was NOT modified
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+	_, exists := xc.Strings["greeting"].Localizations["ja"]
+	if exists {
+		t.Error("dry run should not modify the file")
+	}
+}
+
+func TestImportCommand_Execute_Backup(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\ngreeting,,,translated,Hello,,こんにちは\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", "--backup", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "1 updated") {
+		t.Errorf("expected 1 updated, got: %q", output)
+	}
+
+	// Verify backup file exists
+	bakPath := xcPath + ".bak"
+	if _, err := os.Stat(bakPath); os.IsNotExist(err) {
+		t.Error("backup file should exist")
+	}
+}
+
+func TestImportCommand_Execute_OnMissingKeyError(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\nnonexistent,,,translated,Hello,,こんにちは\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", "--on-missing-key", "error", csvPath})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 1)
+}
+
+func TestImportCommand_Execute_OnMissingKeySkip(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\nnonexistent,,,translated,Hello,,こんにちは\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", "--on-missing-key", "skip", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "1 skipped") {
+		t.Errorf("expected 1 skipped, got: %q", output)
+	}
+}
+
+func TestImportCommand_Execute_ClearEmpty(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+					"ja": {"stringUnit": {"state": "translated", "value": "こんにちは"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\ngreeting,,,translated,Hello,,\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", "--clear-empty", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "1 cleared") {
+		t.Errorf("expected 1 cleared, got: %q", output)
+	}
+
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+
+	loc := xc.Strings["greeting"].Localizations["ja"]
+	if loc.StringUnit != nil {
+		t.Error("expected ja stringUnit to be cleared")
+	}
+}
+
+func TestImportCommand_Execute_EmptyCellSkippedByDefault(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}},
+					"ja": {"stringUnit": {"state": "translated", "value": "こんにちは"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\ngreeting,,,translated,Hello,,\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "0 updated") {
+		t.Errorf("expected 0 updated, got: %q", output)
+	}
+
+	// Verify ja translation was NOT cleared
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+
+	loc := xc.Strings["greeting"].Localizations["ja"]
+	test.AssertEqual(t, loc.StringUnit.Value, "こんにちは")
+}
+
+func TestImportCommand_Execute_MissingFormat(t *testing.T) {
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 1)
+}
+
+func TestImportCommand_Execute_MissingCSVFile(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {},
+		"version": "1.0"
+	}`
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 1)
+}
+
+func TestImportCommand_Execute_CSVFileNotFound(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {},
+		"version": "1.0"
+	}`
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", "nonexistent.csv"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 1)
+}
+
+func TestImportCommand_Execute_SourceLanguageIgnored(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\ngreeting,,,translated,Modified English,,こんにちは\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := test.TempFile(t, "translations.csv", csvContent)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", csvPath})
+	test.AssertNoError(t, err)
+
+	captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	// Verify en was NOT modified
+	xc, err := xcstrings.Load(xcPath)
+	test.AssertNoError(t, err)
+
+	loc := xc.Strings["greeting"].Localizations["en"]
+	test.AssertEqual(t, loc.StringUnit.Value, "Hello")
+}
+
+func TestParseKeyBracket(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantKey   string
+		wantSuffix string
+	}{
+		{"greeting", "greeting", ""},
+		{"item_count[plural.one]", "item_count", "plural.one"},
+		{"welcome[device.iphone]", "welcome", "device.iphone"},
+		{"photos[device.iphone.plural.one]", "photos", "device.iphone.plural.one"},
+		{"file_summary[substitutions.files.plural.one]", "file_summary", "substitutions.files.plural.one"},
+	}
+
+	for _, tt := range tests {
+		key, suffix := parseKeyBracket(tt.input)
+		if key != tt.wantKey {
+			t.Errorf("parseKeyBracket(%q) key = %q, want %q", tt.input, key, tt.wantKey)
+		}
+		if suffix != tt.wantSuffix {
+			t.Errorf("parseKeyBracket(%q) suffix = %q, want %q", tt.input, suffix, tt.wantSuffix)
+		}
+	}
+}
+
+func TestParseHeader(t *testing.T) {
+	header := []string{"key", "comment", "shouldTranslate", "en:state", "en", "ja:state", "ja"}
+	cols, err := parseHeader(header)
+	test.AssertNoError(t, err)
+
+	if len(cols) != 2 {
+		t.Fatalf("expected 2 language columns, got %d", len(cols))
+	}
+	test.AssertEqual(t, cols[0].lang, "en")
+	test.AssertEqual(t, cols[0].stateIdx, 3)
+	test.AssertEqual(t, cols[0].valueIdx, 4)
+	test.AssertEqual(t, cols[1].lang, "ja")
+	test.AssertEqual(t, cols[1].stateIdx, 5)
+	test.AssertEqual(t, cols[1].valueIdx, 6)
+}
+
+func TestImportCommand_Execute_OutputFile(t *testing.T) {
+	xcContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"greeting": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Hello"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	csvContent := "key,comment,shouldTranslate,en:state,en,ja:state,ja\ngreeting,,,translated,Hello,,こんにちは\n"
+
+	xcPath := test.TempFile(t, "test.xcstrings", xcContent)
+	csvPath := filepath.Join(filepath.Dir(xcPath), "translations.csv")
+	os.WriteFile(csvPath, []byte(csvContent), 0644)
+
+	cmd := &ImportCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", xcPath, "--format", "csv", csvPath})
+	test.AssertNoError(t, err)
+
+	output := captureOutput(func() {
+		status := cmd.Execute(context.Background(), flagSet)
+		test.AssertEqual(t, int(status), 0)
+	})
+
+	if !strings.Contains(output, "Imported") {
+		t.Errorf("expected Imported output, got: %q", output)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 
 func main() {
 	subcommands.Register(&command.ExportCommand{}, "")
+	subcommands.Register(&command.ImportCommand{}, "")
 	subcommands.Register(&command.UntranslatedCommand{}, "")
 	subcommands.Register(&command.ListCommand{}, "")
 	subcommands.Register(&command.SetCommand{}, "")


### PR DESCRIPTION
## Summary
- Add import command with --format csv
- Supports variation key parsing from bracket notation
- --dry-run, --backup, --on-missing-key, --clear-empty flags

## Test plan
- [x] make test passes

Closes #29