### PR TITLE
fix: add export, import, stale to integration test expectedCommands

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -71,7 +71,7 @@ func TestIntegration_Help(t *testing.T) {
 	test.AssertEqual(t, stderr, "")
 
 	// Should contain subcommands
-	expectedCommands := []string{"list", "untranslated", "set", "status", "version"}
+	expectedCommands := []string{"export", "import", "list", "untranslated", "set", "stale", "status", "version"}
 	for _, cmd := range expectedCommands {
 		if !strings.Contains(stdout, cmd) {
 			t.Errorf("help output should contain %q, got: %q", cmd, stdout)


### PR DESCRIPTION
## Summary
- Add `export`, `import`, and `stale` commands to the `expectedCommands` slice in `TestIntegration_Help`
- Ensures integration test verifies all registered subcommands appear in help output

## Test plan
- [x] make test passes

Closes #48