### PR TITLE
fix: include source language in list display output

### DIFF
--- a/formatter/display.go
+++ b/formatter/display.go
@@ -19,10 +19,14 @@ func DisplayKeyDetails(x *xcstrings.XCStrings, keys []string) {
 		}
 		definition := x.Strings[key]
 
-		// Build the full list of languages to display: non-source languages
-		// from the catalog plus any language in this key's localizations that
-		// has variations (which may include the source language).
+		// Build the full list of languages to display: the source language
+		// (the canonical reference value) plus all non-source languages from
+		// the catalog, plus any language in this key's localizations that has
+		// variations.
 		langSet := make(map[string]bool)
+		if x.SourceLanguage != "" {
+			langSet[x.SourceLanguage] = true
+		}
 		for _, l := range languages {
 			langSet[l] = true
 		}

--- a/formatter/display_test.go
+++ b/formatter/display_test.go
@@ -316,7 +316,7 @@ func TestDisplayKeyDetails_LanguageSorting(t *testing.T) {
 		DisplayKeyDetails(xcstringsData, []string{"sort_test"})
 	})
 
-	// Languages should appear in alphabetical order: es, ja, zh (en excluded as source language)
+	// Languages should appear in alphabetical order: en, es, ja, zh (source language included)
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 
 	var languageOrder []string
@@ -329,7 +329,7 @@ func TestDisplayKeyDetails_LanguageSorting(t *testing.T) {
 		}
 	}
 
-	expectedOrder := []string{"es", "ja", "zh"} // en is excluded as source language
+	expectedOrder := []string{"en", "es", "ja", "zh"} // source language included
 	if len(languageOrder) != len(expectedOrder) {
 		t.Errorf("expected %d languages, got %d", len(expectedOrder), len(languageOrder))
 		return
@@ -534,6 +534,37 @@ func TestDisplayKeyDetails_SubstitutionsFromFixture(t *testing.T) {
 			if !strings.Contains(output, pattern) {
 				t.Errorf("expected output to contain %q, got:\n%s", pattern, output)
 			}
+		}
+	}
+}
+
+func TestDisplayKeyDetails_IncludesSourceLanguage(t *testing.T) {
+	xcstringsData := &xcstrings.XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]xcstrings.StringDefinition{
+			"some.key.prefix.title": {
+				Localizations: map[string]xcstrings.Localization{
+					"en": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Import Error"}},
+					"de": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "Importfehler"}},
+					"ja": {StringUnit: &xcstrings.StringUnit{State: "translated", Value: "インポートエラー"}},
+				},
+			},
+		},
+	}
+
+	output := captureOutput(func() {
+		DisplayKeyDetails(xcstringsData, []string{"some.key.prefix.title"})
+	})
+
+	expectedPatterns := []string{
+		"some.key.prefix.title:",
+		"en: translated - Import Error",
+		"de: translated - Importfehler",
+		"ja: translated - インポートエラー",
+	}
+	for _, expected := range expectedPatterns {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected output to contain %q, got:\n%s", expected, output)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`DisplayKeyDetails` built its language set from `x.Languages()`, which deliberately excludes `SourceLanguage`. As a result, the per-key block under `list --prefix` omitted the canonical source value used as the reference for every translation.

## Change

Seed `langSet` with `x.SourceLanguage` unconditionally (guarded against empty) so the source row appears alphabetically alongside other languages. `Languages()` keeps its non-source semantics intact — `untranslated`/`translated` key calculations are unaffected.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] New `TestDisplayKeyDetails_IncludesSourceLanguage` covers the issue example (`some.key.prefix.title` with en/de/ja)
- [x] `TestDisplayKeyDetails_LanguageSorting` updated to assert en is included alphabetically

Closes #73