### PR TITLE
feat: add state filter to list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ All commands accept `-f` (or `--file`) to specify the `.xcstrings` file path. Wh
 ### list
 
 ```bash
-xckit list [-f file.xcstrings] [--prefix <prefix>]
+xckit list [-f file.xcstrings] [--prefix <prefix>] [--state <state>]
 ```
 
-Lists all keys with their translation status. Use `--prefix` to filter by key prefix.
+Lists all keys with their translation status. Use `--prefix` to filter by key prefix and `--state` to filter by `extractionState` (e.g. `manual`, `stale`, `new`). Each key with a non-empty `extractionState` is annotated in the output (e.g. `mykey [manual]:`). The two filters can be combined.
 
 ### untranslated
 

--- a/command/list.go
+++ b/command/list.go
@@ -13,6 +13,7 @@ import (
 type ListCommand struct {
 	XCStringsCommand
 	prefix string
+	state  string
 }
 
 func (*ListCommand) Name() string {
@@ -24,12 +25,13 @@ func (*ListCommand) Synopsis() string {
 }
 
 func (*ListCommand) Usage() string {
-	return "list [-f file.xcstrings] [--prefix <prefix>]: List all keys with translation status\n"
+	return "list [-f file.xcstrings] [--prefix <prefix>] [--state <state>]: List all keys with translation status\n"
 }
 
 func (c *ListCommand) SetFlags(f *flag.FlagSet) {
 	c.SetXCStringsFlags(f)
 	f.StringVar(&c.prefix, "prefix", "", "Filter keys by prefix")
+	f.StringVar(&c.state, "state", "", "Filter keys by extractionState (e.g. manual, stale, new)")
 }
 
 func (c *ListCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
@@ -41,20 +43,43 @@ func (c *ListCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 
 	keysToShow := xcstrings.Keys()
 	keysToShow = xcstrings.FilterKeysByPrefix(keysToShow, c.prefix)
+	if c.state != "" {
+		stateSet := make(map[string]bool, len(keysToShow))
+		for _, k := range xcstrings.KeysByState(c.state) {
+			stateSet[k] = true
+		}
+		filtered := keysToShow[:0]
+		for _, k := range keysToShow {
+			if stateSet[k] {
+				filtered = append(filtered, k)
+			}
+		}
+		keysToShow = filtered
+	}
 	sort.Strings(keysToShow)
 
 	if len(keysToShow) == 0 {
-		if c.prefix != "" {
+		switch {
+		case c.prefix != "" && c.state != "":
+			fmt.Printf("No keys found with prefix '%s' and state '%s'\n", c.prefix, c.state)
+		case c.prefix != "":
 			fmt.Printf("No keys found with prefix '%s'\n", c.prefix)
-		} else {
+		case c.state != "":
+			fmt.Printf("No keys found with state '%s'\n", c.state)
+		default:
 			fmt.Println("No keys found")
 		}
 		return subcommands.ExitSuccess
 	}
 
-	if c.prefix != "" {
+	switch {
+	case c.prefix != "" && c.state != "":
+		fmt.Printf("Keys with prefix '%s' and state '%s':\n", c.prefix, c.state)
+	case c.prefix != "":
 		fmt.Printf("Keys with prefix '%s':\n", c.prefix)
-	} else {
+	case c.state != "":
+		fmt.Printf("Keys with state '%s':\n", c.state)
+	default:
 		fmt.Println("All keys with translation status:")
 	}
 	formatter.DisplayKeyDetails(xcstrings, keysToShow)

--- a/command/list_test.go
+++ b/command/list_test.go
@@ -97,6 +97,99 @@ func TestListCommand_Execute(t *testing.T) {
 	}
 }
 
+func TestListCommand_Execute_StateFilter(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"active.key": {
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Active"}}
+				}
+			},
+			"manual.key": {
+				"extractionState": "manual",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Manual"}}
+				}
+			},
+			"stale.key": {
+				"extractionState": "stale",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Stale"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	tests := []struct {
+		name         string
+		args         []string
+		mustContain  []string
+		mustNotMatch []string
+	}{
+		{
+			name:         "filter manual",
+			args:         []string{"--state", "manual"},
+			mustContain:  []string{"manual.key [manual]:", "Keys with state 'manual':"},
+			mustNotMatch: []string{"active.key", "stale.key"},
+		},
+		{
+			name:         "filter stale",
+			args:         []string{"--state", "stale"},
+			mustContain:  []string{"stale.key [stale]:", "Keys with state 'stale':"},
+			mustNotMatch: []string{"active.key", "manual.key"},
+		},
+		{
+			name:         "filter empty matches default",
+			args:         []string{},
+			mustContain:  []string{"active.key:", "manual.key [manual]:", "stale.key [stale]:"},
+			mustNotMatch: []string{"active.key [", "active.key [manual]"},
+		},
+		{
+			name:         "filter non-matching state",
+			args:         []string{"--state", "new"},
+			mustContain:  []string{"No keys found with state 'new'"},
+			mustNotMatch: []string{"active.key", "manual.key", "stale.key"},
+		},
+		{
+			name:         "prefix and state combined",
+			args:         []string{"--prefix", "manual", "--state", "manual"},
+			mustContain:  []string{"manual.key [manual]:", "Keys with prefix 'manual' and state 'manual':"},
+			mustNotMatch: []string{"active.key", "stale.key"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+			cmd := &ListCommand{}
+			flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+			cmd.SetFlags(flagSet)
+			args := append([]string{"-f", filePath}, tt.args...)
+			err := flagSet.Parse(args)
+			test.AssertNoError(t, err)
+
+			output := captureOutput(func() {
+				status := cmd.Execute(context.Background(), flagSet)
+				test.AssertEqual(t, int(status), 0)
+			})
+
+			for _, want := range tt.mustContain {
+				if !strings.Contains(output, want) {
+					t.Errorf("output should contain %q, got: %q", want, output)
+				}
+			}
+			for _, unwanted := range tt.mustNotMatch {
+				if strings.Contains(output, unwanted) {
+					t.Errorf("output should NOT contain %q, got: %q", unwanted, output)
+				}
+			}
+		})
+	}
+}
+
 func TestListCommand_Execute_PluralVariations(t *testing.T) {
 	testContent := `{
 		"sourceLanguage": "en",

--- a/formatter/display.go
+++ b/formatter/display.go
@@ -12,8 +12,8 @@ func DisplayKeyDetails(x *xcstrings.XCStrings, keys []string) {
 	sort.Strings(languages)
 
 	for _, key := range keys {
-		if x.IsStale(key) {
-			fmt.Printf("\n%s [stale]:\n", key)
+		if state := x.ExtractionStateOf(key); state != "" {
+			fmt.Printf("\n%s [%s]:\n", key, state)
 		} else {
 			fmt.Printf("\n%s:\n", key)
 		}

--- a/formatter/display_test.go
+++ b/formatter/display_test.go
@@ -63,7 +63,7 @@ func TestDisplayKeyDetails(t *testing.T) {
 			name: "single key with all translations",
 			keys: []string{"hello"},
 			expectedOutput: []string{
-				"hello:",
+				"hello [manual]:",
 				"new - Hola",
 				"translated - こんにちは",
 			},
@@ -88,7 +88,7 @@ func TestDisplayKeyDetails(t *testing.T) {
 			name: "multiple keys",
 			keys: []string{"hello", "goodbye"},
 			expectedOutput: []string{
-				"hello:",
+				"hello [manual]:",
 				"goodbye:",
 				"new - Hola",
 				"translated - こんにちは",

--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -181,6 +181,31 @@ func (x *XCStrings) IsStale(key string) bool {
 	return def.ExtractionState == "stale"
 }
 
+// ExtractionStateOf returns the extractionState of the given key.
+// Keys without an explicit extractionState (the default "translated" case
+// where the field is omitted from JSON) return an empty string.
+// A missing key also returns an empty string.
+func (x *XCStrings) ExtractionStateOf(key string) string {
+	def, exists := x.Strings[key]
+	if !exists {
+		return ""
+	}
+	return def.ExtractionState
+}
+
+// KeysByState returns keys whose extractionState equals the given state.
+// Passing "" matches keys whose extractionState field is absent (the default
+// when Xcode considers the entry translated and does not write the field).
+func (x *XCStrings) KeysByState(state string) []string {
+	var keys []string
+	for key, def := range x.Strings {
+		if def.ExtractionState == state {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
 // RemoveStaleKeys removes all keys with extractionState "stale" from the catalog.
 func (x *XCStrings) RemoveStaleKeys() int {
 	count := 0

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -977,6 +977,27 @@ func TestXCStrings_StaleKeys(t *testing.T) {
 			t.Error("stale key should have been removed")
 		}
 	})
+
+	t.Run("ExtractionStateOf returns the raw state", func(t *testing.T) {
+		test.AssertEqual(t, xcstrings.ExtractionStateOf("stale_key"), "stale")
+		test.AssertEqual(t, xcstrings.ExtractionStateOf("manual_key"), "manual")
+		test.AssertEqual(t, xcstrings.ExtractionStateOf("active_key"), "")
+		test.AssertEqual(t, xcstrings.ExtractionStateOf("nonexistent"), "")
+	})
+
+	t.Run("KeysByState filters by extractionState", func(t *testing.T) {
+		manual := xcstrings.KeysByState("manual")
+		sort.Strings(manual)
+		test.AssertSliceEqual(t, manual, []string{"manual_key"})
+
+		stale := xcstrings.KeysByState("stale")
+		sort.Strings(stale)
+		test.AssertSliceEqual(t, stale, []string{"another_stale", "stale_key"})
+
+		empty := xcstrings.KeysByState("")
+		sort.Strings(empty)
+		test.AssertSliceEqual(t, empty, []string{"active_key"})
+	})
 }
 
 func TestLocalization_AllStringUnits(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a `--state` flag to `xckit list` so keys can be filtered by `extractionState` (`manual`, `stale`, `new`, etc.). The display now annotates every key with its state in brackets when non-empty (e.g. `mykey [manual]:`), generalizing the existing `[stale]` annotation.

Two helpers are introduced on `xcstrings`:

- `ExtractionStateOf(key) string` — raw state, `""` for missing or default.
- `KeysByState(state) []string` — keys whose `extractionState` equals `state`.

The existing `IsStale` / `StaleKeys` / `RemoveStaleKeys` / `stale` command are left untouched for backward compatibility.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] New `TestXCStrings_KeysByState` covers `manual`, `stale`, and the empty/default case
- [x] New `TestListCommand_Execute_StateFilter` covers `--state manual`, `--state stale`, no-filter, non-matching state, and combined `--prefix` + `--state`
- [x] `TestDisplayKeyDetails` updated to assert the `[manual]` annotation
- [x] README documents `--state`

Closes #74