### PR TITLE
feat: add remove command and make set upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ xckit import --format csv -f MyApp.xcstrings translations.csv
 |----------------|----------------------------------------------------------|
 | `list`         | List all keys with translation status                    |
 | `untranslated` | Find keys that need translation                          |
-| `set`          | Set a translation for a specific key and language        |
+| `set`          | Set a translation, creating the key if missing           |
+| `remove`       | Remove a key by name or by extractionState               |
 | `status`       | Show translation progress summary per language           |
 | `export`       | Export strings to CSV                                    |
 | `import`       | Import translations from CSV                             |
@@ -102,16 +103,30 @@ Shows keys that need translation. Without `--lang`, returns keys with any untran
 ### set
 
 ```bash
-xckit set [-f file.xcstrings] --lang <language> [--plural <category>] [--device <device>] [--force] <key> <value>
+xckit set [-f file.xcstrings] --lang <language> [--plural <category>] [--device <device>] [--state <state>] [--force] <key> <value>
 ```
 
-Sets a translation for a specific key and language.
+Sets a translation for the given key/language. The key is created when it does not yet exist; existing keys are updated in place.
 
 - `--plural`: Set a plural variation (`zero`, `one`, `two`, `few`, `many`, `other`)
 - `--device`: Set a device variation (`iphone`, `ipad`, `mac`, `appletv`, `applewatch`, `applevision`, `other`)
+- `--state`: `extractionState` applied only when the key is created (e.g. `manual`). Ignored when the key already exists.
 - `--force`: Suppress the migration warning when converting a plain string to variations
 
 Plural and device flags can be combined to set nested variations (e.g., device > plural).
+
+### remove
+
+```bash
+xckit remove [-f file.xcstrings] [--state <state>] [--dry-run] [<key>]
+```
+
+Removes a key from the catalog regardless of its `extractionState`.
+
+- `<key>`: Remove that single key. Errors if the key does not exist.
+- `--state <state>`: Remove every key whose `extractionState` matches (e.g. `stale`, `manual`).
+- Combining `<key>` and `--state`: removes the named key only if its state matches.
+- `--dry-run`: Print the keys that would be removed without modifying the file.
 
 ### status
 

--- a/command/import.go
+++ b/command/import.go
@@ -244,7 +244,11 @@ func parseKeyBracket(raw string) (string, string) {
 // setTranslation sets a translation value, handling both simple and variation keys.
 func setTranslation(xc *xcstrings.XCStrings, key, lang, value, variationPath string) error {
 	if variationPath == "" {
-		return xc.SetTranslation(key, lang, value)
+		if _, exists := xc.Strings[key]; !exists {
+			return fmt.Errorf("key '%s' not found", key)
+		}
+		_, err := xc.SetTranslation(key, lang, value, "")
+		return err
 	}
 
 	parts := splitPath(variationPath)
@@ -259,7 +263,10 @@ func setTranslation(xc *xcstrings.XCStrings, key, lang, value, variationPath str
 	if err != nil {
 		return err
 	}
-	_, err = xc.SetVariationTranslation(key, lang, value, opts)
+	if _, exists := xc.Strings[key]; !exists {
+		return fmt.Errorf("key '%s' not found", key)
+	}
+	_, _, err = xc.SetVariationTranslation(key, lang, value, opts, "")
 	return err
 }
 

--- a/command/remove.go
+++ b/command/remove.go
@@ -1,0 +1,98 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+
+	"github.com/google/subcommands"
+)
+
+type RemoveCommand struct {
+	XCStringsCommand
+	state  string
+	dryRun bool
+}
+
+func (*RemoveCommand) Name() string {
+	return "remove"
+}
+
+func (*RemoveCommand) Synopsis() string {
+	return "Remove a key, or all keys matching an extractionState"
+}
+
+func (*RemoveCommand) Usage() string {
+	return "remove [-f file.xcstrings] [--state <state>] [--dry-run] [<key>]: Remove a single key by name, or all keys matching --state. --dry-run prints what would be removed without modifying the file.\n"
+}
+
+func (c *RemoveCommand) SetFlags(f *flag.FlagSet) {
+	c.SetXCStringsFlags(f)
+	f.StringVar(&c.state, "state", "", "Remove every key whose extractionState matches this value (e.g. stale, manual)")
+	f.BoolVar(&c.dryRun, "dry-run", false, "Print what would be removed without modifying the file")
+}
+
+func (c *RemoveCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	hasKey := f.NArg() >= 1
+	if !hasKey && c.state == "" {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: either <key> or --state is required\n")
+		fmt.Fprint(flag.CommandLine.Output(), c.Usage())
+		return subcommands.ExitUsageError
+	}
+
+	xcs, err := c.LoadXCStrings()
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	var targets []string
+	if hasKey {
+		key := f.Arg(0)
+		if _, exists := xcs.Strings[key]; !exists {
+			fmt.Fprintf(flag.CommandLine.Output(), "Error: key '%s' not found\n", key)
+			return subcommands.ExitFailure
+		}
+		if c.state != "" && xcs.ExtractionStateOf(key) != c.state {
+			fmt.Fprintf(flag.CommandLine.Output(), "Error: key '%s' has extractionState '%s', not '%s'\n", key, xcs.ExtractionStateOf(key), c.state)
+			return subcommands.ExitFailure
+		}
+		targets = []string{key}
+	} else {
+		targets = xcs.KeysByState(c.state)
+		sort.Strings(targets)
+	}
+
+	if len(targets) == 0 {
+		fmt.Printf("No keys found with state '%s'\n", c.state)
+		return subcommands.ExitSuccess
+	}
+
+	if c.dryRun {
+		fmt.Printf("Would remove %d key(s):\n", len(targets))
+		for _, key := range targets {
+			fmt.Printf("  %s\n", key)
+		}
+		return subcommands.ExitSuccess
+	}
+
+	removed := 0
+	for _, key := range targets {
+		if xcs.RemoveKey(key) {
+			removed++
+		}
+	}
+
+	filePath := c.filePath
+	if filePath == "" {
+		filePath = c.findXCStringsFile()
+	}
+	if err := xcs.SaveToFile(filePath); err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Error saving file: %v\n", err)
+		return subcommands.ExitFailure
+	}
+
+	fmt.Printf("Removed %d key(s)\n", removed)
+	return subcommands.ExitSuccess
+}

--- a/command/remove_test.go
+++ b/command/remove_test.go
@@ -1,0 +1,172 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"strings"
+	"testing"
+
+	"xckit/helper/test"
+	"xckit/xcstrings"
+)
+
+const removeFixture = `{
+	"sourceLanguage": "en",
+	"strings": {
+		"active.key": {
+			"localizations": {
+				"en": {"stringUnit": {"state": "translated", "value": "Active"}}
+			}
+		},
+		"manual.key": {
+			"extractionState": "manual",
+			"localizations": {
+				"en": {"stringUnit": {"state": "translated", "value": "Manual"}}
+			}
+		},
+		"stale.one": {
+			"extractionState": "stale",
+			"localizations": {
+				"en": {"stringUnit": {"state": "translated", "value": "Stale 1"}}
+			}
+		},
+		"stale.two": {
+			"extractionState": "stale",
+			"localizations": {
+				"en": {"stringUnit": {"state": "translated", "value": "Stale 2"}}
+			}
+		}
+	},
+	"version": "1.0"
+}`
+
+func runRemove(t *testing.T, filePath string, args ...string) (int, string) {
+	t.Helper()
+	cmd := &RemoveCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(&strings.Builder{})
+	cmd.SetFlags(flagSet)
+	parseArgs := append([]string{"-f", filePath}, args...)
+	if err := flagSet.Parse(parseArgs); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var status int
+	output := captureOutput(func() {
+		status = int(cmd.Execute(context.Background(), flagSet))
+	})
+	return status, output
+}
+
+func TestRemoveCommand_Execute_SingleKey(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+
+	status, output := runRemove(t, filePath, "manual.key")
+	test.AssertEqual(t, status, 0)
+	if !strings.Contains(output, "Removed 1 key(s)") {
+		t.Errorf("expected success message, got %q", output)
+	}
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	if _, exists := xc.Strings["manual.key"]; exists {
+		t.Error("manual.key should have been removed")
+	}
+}
+
+func TestRemoveCommand_Execute_ByStateStale(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+
+	status, _ := runRemove(t, filePath, "--state", "stale")
+	test.AssertEqual(t, status, 0)
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	if _, exists := xc.Strings["stale.one"]; exists {
+		t.Error("stale.one should have been removed")
+	}
+	if _, exists := xc.Strings["stale.two"]; exists {
+		t.Error("stale.two should have been removed")
+	}
+	if _, exists := xc.Strings["active.key"]; !exists {
+		t.Error("active.key should still exist")
+	}
+}
+
+func TestRemoveCommand_Execute_ByStateManual(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+
+	status, _ := runRemove(t, filePath, "--state", "manual")
+	test.AssertEqual(t, status, 0)
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	if _, exists := xc.Strings["manual.key"]; exists {
+		t.Error("manual.key should have been removed")
+	}
+}
+
+func TestRemoveCommand_Execute_KeyStateMismatchRefused(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+
+	status, _ := runRemove(t, filePath, "--state", "stale", "manual.key")
+	test.AssertEqual(t, status, 1)
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	if _, exists := xc.Strings["manual.key"]; !exists {
+		t.Error("manual.key should still exist after state mismatch refusal")
+	}
+}
+
+func TestRemoveCommand_Execute_SingleKeyDryRun(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+
+	status, output := runRemove(t, filePath, "--dry-run", "manual.key")
+	test.AssertEqual(t, status, 0)
+	if !strings.Contains(output, "Would remove 1 key(s)") {
+		t.Errorf("expected dry-run summary, got %q", output)
+	}
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	if _, exists := xc.Strings["manual.key"]; !exists {
+		t.Error("dry-run must not modify the file")
+	}
+}
+
+func TestRemoveCommand_Execute_DryRun(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+
+	status, output := runRemove(t, filePath, "--state", "stale", "--dry-run")
+	test.AssertEqual(t, status, 0)
+	if !strings.Contains(output, "Would remove 2 key(s)") {
+		t.Errorf("expected dry-run summary, got %q", output)
+	}
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	if _, exists := xc.Strings["stale.one"]; !exists {
+		t.Error("dry-run must not modify the file")
+	}
+}
+
+func TestRemoveCommand_Execute_MissingKey(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+	status, _ := runRemove(t, filePath, "nonexistent")
+	test.AssertEqual(t, status, 1)
+}
+
+func TestRemoveCommand_Execute_NoArgs(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+	status, _ := runRemove(t, filePath)
+	test.AssertEqual(t, status, 2) // ExitUsageError
+}
+
+func TestRemoveCommand_Execute_StateWithNoMatches(t *testing.T) {
+	filePath := test.TempFile(t, "test.xcstrings", removeFixture)
+	status, output := runRemove(t, filePath, "--state", "new")
+	test.AssertEqual(t, status, 0)
+	if !strings.Contains(output, "No keys found with state 'new'") {
+		t.Errorf("expected no-keys message, got %q", output)
+	}
+}

--- a/command/set.go
+++ b/command/set.go
@@ -17,6 +17,7 @@ type SetCommand struct {
 	language string
 	plural   string
 	device   string
+	state    string
 	force    bool
 }
 
@@ -29,7 +30,7 @@ func (*SetCommand) Synopsis() string {
 }
 
 func (*SetCommand) Usage() string {
-	return "set [-f file.xcstrings] --lang <language> [--plural <category>] [--device <device>] [--force] <key> <value>: Set translation for a specific key and language\n"
+	return "set [-f file.xcstrings] --lang <language> [--plural <category>] [--device <device>] [--state <state>] [--force] <key> <value>: Set translation, creating the key if it does not yet exist\n"
 }
 
 func (c *SetCommand) SetFlags(f *flag.FlagSet) {
@@ -37,6 +38,7 @@ func (c *SetCommand) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&c.language, "lang", "", "Target language code (e.g., ja, fr, de)")
 	f.StringVar(&c.plural, "plural", "", "Plural category (zero, one, two, few, many, other)")
 	f.StringVar(&c.device, "device", "", "Device variation (iphone, ipad, mac, appletv, applewatch, applevision, other)")
+	f.StringVar(&c.state, "state", "", "extractionState applied when the key is newly created (e.g. manual). Ignored when the key already exists.")
 	f.BoolVar(&c.force, "force", false, "Suppress migration warning when converting plain stringUnit to variations")
 }
 
@@ -72,24 +74,28 @@ func (c *SetCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		return subcommands.ExitFailure
 	}
 
+	created := false
 	if c.plural != "" || c.device != "" {
 		opts := xcstrings.VariationOptions{
 			Plural: c.plural,
 			Device: c.device,
 		}
-		migrated, err := xcs.SetVariationTranslation(key, c.language, value, opts)
+		migrated, wasCreated, err := xcs.SetVariationTranslation(key, c.language, value, opts, c.state)
 		if err != nil {
 			fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
 			return subcommands.ExitFailure
 		}
+		created = wasCreated
 		if migrated && !c.force {
 			fmt.Fprintf(os.Stderr, "Warning: existing plain stringUnit for key '%s' in language '%s' was migrated to variations\n", key, c.language)
 		}
 	} else {
-		if err := xcs.SetTranslation(key, c.language, value); err != nil {
+		wasCreated, err := xcs.SetTranslation(key, c.language, value, c.state)
+		if err != nil {
 			fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
 			return subcommands.ExitFailure
 		}
+		created = wasCreated
 	}
 
 	filePath := c.filePath
@@ -102,6 +108,10 @@ func (c *SetCommand) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		return subcommands.ExitFailure
 	}
 
-	fmt.Printf("Successfully set translation for key '%s' in language '%s'\n", key, c.language)
+	if created {
+		fmt.Printf("Successfully created key '%s' with translation for language '%s'\n", key, c.language)
+	} else {
+		fmt.Printf("Successfully set translation for key '%s' in language '%s'\n", key, c.language)
+	}
 	return subcommands.ExitSuccess
 }

--- a/command/set_test.go
+++ b/command/set_test.go
@@ -97,7 +97,7 @@ func TestSetCommand_Execute_MissingArguments(t *testing.T) {
 	test.AssertEqual(t, int(status), 2) // ExitUsageError
 }
 
-func TestSetCommand_Execute_NonexistentKey(t *testing.T) {
+func TestSetCommand_Execute_CreatesNewKey(t *testing.T) {
 	testContent := `{
 		"sourceLanguage": "en",
 		"strings": {},
@@ -109,13 +109,79 @@ func TestSetCommand_Execute_NonexistentKey(t *testing.T) {
 	cmd := &SetCommand{}
 
 	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
-	flagSet.SetOutput(&strings.Builder{}) // Suppress error output
+	flagSet.SetOutput(&strings.Builder{})
 	cmd.SetFlags(flagSet)
-	err := flagSet.Parse([]string{"-f", filePath, "--lang", "ja", "nonexistent_key", "value"})
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "ja", "new_key", "値"})
 	test.AssertNoError(t, err)
 
 	status := cmd.Execute(context.Background(), flagSet)
-	test.AssertEqual(t, int(status), 1) // ExitFailure
+	test.AssertEqual(t, int(status), 0)
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	def, exists := xc.Strings["new_key"]
+	if !exists {
+		t.Fatal("new_key should have been created")
+	}
+	test.AssertEqual(t, def.Localizations["ja"].StringUnit.Value, "値")
+	test.AssertEqual(t, def.ExtractionState, "")
+}
+
+func TestSetCommand_Execute_StateIgnoredOnExistingKey(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {
+			"existing": {
+				"extractionState": "manual",
+				"localizations": {
+					"en": {"stringUnit": {"state": "translated", "value": "Old"}}
+				}
+			}
+		},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &SetCommand{}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(&strings.Builder{})
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "en", "--state", "stale", "existing", "New"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 0)
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	test.AssertEqual(t, xc.Strings["existing"].ExtractionState, "manual")
+	test.AssertEqual(t, xc.Strings["existing"].Localizations["en"].StringUnit.Value, "New")
+}
+
+func TestSetCommand_Execute_CreatesNewKeyWithState(t *testing.T) {
+	testContent := `{
+		"sourceLanguage": "en",
+		"strings": {},
+		"version": "1.0"
+	}`
+
+	filePath := test.TempFile(t, "test.xcstrings", testContent)
+
+	cmd := &SetCommand{}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(&strings.Builder{})
+	cmd.SetFlags(flagSet)
+	err := flagSet.Parse([]string{"-f", filePath, "--lang", "en", "--state", "manual", "manual_key", "Hello"})
+	test.AssertNoError(t, err)
+
+	status := cmd.Execute(context.Background(), flagSet)
+	test.AssertEqual(t, int(status), 0)
+
+	xc, err := xcstrings.Load(filePath)
+	test.AssertNoError(t, err)
+	test.AssertEqual(t, xc.Strings["manual_key"].ExtractionState, "manual")
 }
 
 func TestSetCommand_Execute_FileNotFound(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 	subcommands.Register(&command.UntranslatedCommand{}, "")
 	subcommands.Register(&command.ListCommand{}, "")
 	subcommands.Register(&command.SetCommand{}, "")
+	subcommands.Register(&command.RemoveCommand{}, "")
 	subcommands.Register(&command.StaleCommand{}, "")
 	subcommands.Register(&command.StatusCommand{}, "")
 	subcommands.Register(&command.VersionCommand{}, "")

--- a/xcstrings/xcstrings.go
+++ b/xcstrings/xcstrings.go
@@ -269,10 +269,21 @@ func (x *XCStrings) Languages() []string {
 	return languages
 }
 
-func (x *XCStrings) SetTranslation(key, language, value string) error {
+// SetTranslation upserts a plain stringUnit translation for the given key
+// and language. When the key does not exist it is created with the supplied
+// initialState as its extractionState (empty initialState leaves the field
+// unset, matching the Xcode default). Existing keys keep their extractionState
+// untouched. Returns (created, error) where created is true when the key was
+// newly added.
+func (x *XCStrings) SetTranslation(key, language, value, initialState string) (bool, error) {
 	definition, exists := x.Strings[key]
+	created := false
 	if !exists {
-		return fmt.Errorf("key '%s' not found", key)
+		created = true
+		definition = StringDefinition{
+			ExtractionState: initialState,
+			Localizations:   make(map[string]Localization),
+		}
 	}
 
 	if definition.Localizations == nil {
@@ -289,7 +300,17 @@ func (x *XCStrings) SetTranslation(key, language, value string) error {
 	definition.Localizations[language] = loc
 
 	x.Strings[key] = definition
-	return nil
+	return created, nil
+}
+
+// RemoveKey deletes the given key from the catalog regardless of its
+// extractionState. Returns true when the key was present and removed.
+func (x *XCStrings) RemoveKey(key string) bool {
+	if _, exists := x.Strings[key]; !exists {
+		return false
+	}
+	delete(x.Strings, key)
+	return true
 }
 
 // VariationOptions specifies which variation path to set a translation on.
@@ -305,12 +326,21 @@ var ValidPluralCategories = []string{"zero", "one", "two", "few", "many", "other
 var ValidDeviceCategories = []string{"iphone", "ipad", "mac", "appletv", "applewatch", "applevision", "other"}
 
 // SetVariationTranslation sets a translation within a variation structure.
-// It returns (migrated bool, err error) where migrated indicates that an existing
-// plain stringUnit was converted to a variation structure.
-func (x *XCStrings) SetVariationTranslation(key, language, value string, opts VariationOptions) (bool, error) {
+// When the key does not yet exist it is created with initialState as its
+// extractionState (empty initialState leaves the field unset). Existing keys
+// keep their extractionState untouched.
+// It returns (migrated, created, err) where migrated indicates that an
+// existing plain stringUnit was converted to a variation structure, and
+// created indicates that the key was newly added.
+func (x *XCStrings) SetVariationTranslation(key, language, value string, opts VariationOptions, initialState string) (bool, bool, error) {
 	definition, exists := x.Strings[key]
+	created := false
 	if !exists {
-		return false, fmt.Errorf("key '%s' not found", key)
+		created = true
+		definition = StringDefinition{
+			ExtractionState: initialState,
+			Localizations:   make(map[string]Localization),
+		}
 	}
 
 	if definition.Localizations == nil {
@@ -371,7 +401,7 @@ func (x *XCStrings) SetVariationTranslation(key, language, value string, opts Va
 
 	definition.Localizations[language] = loc
 	x.Strings[key] = definition
-	return migrated, nil
+	return migrated, created, nil
 }
 
 // KeysWithAnyUntranslated returns keys that have at least one untranslated language.

--- a/xcstrings/xcstrings_test.go
+++ b/xcstrings/xcstrings_test.go
@@ -281,40 +281,34 @@ func TestXCStrings_SetTranslation(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		key      string
-		language string
-		value    string
-		wantErr  bool
+		name        string
+		key         string
+		language    string
+		value       string
+		wantCreated bool
 	}{
 		{
-			name:     "set existing key",
-			key:      "existing_key",
-			language: "ja",
-			value:    "既存",
-			wantErr:  false,
+			name:        "set existing key",
+			key:         "existing_key",
+			language:    "ja",
+			value:       "既存",
+			wantCreated: false,
 		},
 		{
-			name:     "set nonexistent key",
-			key:      "nonexistent_key",
-			language: "ja",
-			value:    "存在しない",
-			wantErr:  true,
+			name:        "set nonexistent key creates it",
+			key:         "nonexistent_key",
+			language:    "ja",
+			value:       "新規",
+			wantCreated: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := xcstrings.SetTranslation(tt.key, tt.language, tt.value)
-
-			if tt.wantErr {
-				test.AssertError(t, err)
-				return
-			}
-
+			created, err := xcstrings.SetTranslation(tt.key, tt.language, tt.value, "")
 			test.AssertNoError(t, err)
+			test.AssertEqual(t, created, tt.wantCreated)
 
-			// Verify the translation was set
 			localization, exists := xcstrings.Strings[tt.key].Localizations[tt.language]
 			if !exists {
 				t.Errorf("translation not set for key %s, language %s", tt.key, tt.language)
@@ -325,6 +319,42 @@ func TestXCStrings_SetTranslation(t *testing.T) {
 			test.AssertEqual(t, localization.StringUnit.Value, tt.value)
 		})
 	}
+}
+
+func TestXCStrings_SetTranslation_CreatesWithInitialState(t *testing.T) {
+	x := &XCStrings{SourceLanguage: "en", Strings: map[string]StringDefinition{}}
+	created, err := x.SetTranslation("new.key", "en", "Hello", "manual")
+	test.AssertNoError(t, err)
+	test.AssertEqual(t, created, true)
+	test.AssertEqual(t, x.Strings["new.key"].ExtractionState, "manual")
+}
+
+func TestXCStrings_SetTranslation_DoesNotOverrideExistingState(t *testing.T) {
+	x := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"keep.state": {
+				ExtractionState: "manual",
+				Localizations:   map[string]Localization{},
+			},
+		},
+	}
+	created, err := x.SetTranslation("keep.state", "ja", "テスト", "stale")
+	test.AssertNoError(t, err)
+	test.AssertEqual(t, created, false)
+	test.AssertEqual(t, x.Strings["keep.state"].ExtractionState, "manual")
+}
+
+func TestXCStrings_RemoveKey(t *testing.T) {
+	x := &XCStrings{
+		SourceLanguage: "en",
+		Strings: map[string]StringDefinition{
+			"present": {},
+		},
+	}
+	test.AssertEqual(t, x.RemoveKey("present"), true)
+	test.AssertEqual(t, len(x.Strings), 0)
+	test.AssertEqual(t, x.RemoveKey("absent"), false)
 }
 
 func TestXCStrings_SetTranslation_PreservesExistingLocalization(t *testing.T) {
@@ -343,7 +373,7 @@ func TestXCStrings_SetTranslation_PreservesExistingLocalization(t *testing.T) {
 	}
 
 	// Update the Japanese translation
-	err := xcstrings.SetTranslation("greeting", "ja", "やあ")
+	_, err := xcstrings.SetTranslation("greeting", "ja", "やあ", "")
 	test.AssertNoError(t, err)
 
 	// Verify the translation was updated
@@ -380,7 +410,7 @@ func TestXCStrings_SetTranslation_ClearsVariations(t *testing.T) {
 		},
 	}
 
-	err := xcstrings.SetTranslation("items_count", "ja", "アイテム")
+	_, err := xcstrings.SetTranslation("items_count", "ja", "アイテム", "")
 	test.AssertNoError(t, err)
 
 	loc := xcstrings.Strings["items_count"].Localizations["ja"]
@@ -419,7 +449,7 @@ func TestXCStrings_SetTranslation_ClearsSubstitutions(t *testing.T) {
 		},
 	}
 
-	err := xcstrings.SetTranslation("file_count", "ja", "ファイル")
+	_, err := xcstrings.SetTranslation("file_count", "ja", "ファイル", "")
 	test.AssertNoError(t, err)
 
 	loc := xcstrings.Strings["file_count"].Localizations["ja"]
@@ -453,7 +483,7 @@ func TestXCStrings_SetTranslation_ClearsVariations_RoundTrip(t *testing.T) {
 		Version: "1.0",
 	}
 
-	err := xcstrings.SetTranslation("items_count", "ja", "アイテム")
+	_, err := xcstrings.SetTranslation("items_count", "ja", "アイテム", "")
 	test.AssertNoError(t, err)
 
 	tmpDir := t.TempDir()
@@ -601,7 +631,7 @@ func TestXCStrings_LoadEmptyLocalizationsInitialized(t *testing.T) {
 	}
 
 	// Modify another key
-	err = xcstrings.SetTranslation("test", "ja", "テスト")
+	_, err = xcstrings.SetTranslation("test", "ja", "テスト", "")
 	test.AssertNoError(t, err)
 
 	// Save the file


### PR DESCRIPTION
## Summary

- New `remove` subcommand deletes a key by name or every key matching `--state`. `--dry-run` prints the would-remove list without modifying the file. Combining `<key>` with `--state` only removes the named key when its `extractionState` matches.
- `set` is now upsert. When the target key does not yet exist it is created. A new `--state` flag sets `extractionState` at creation time only; existing keys keep their current state.
- `SetTranslation` and `SetVariationTranslation` now return whether the key was newly created.
- `import` is unchanged for users — it still rejects missing keys, now via an explicit existence check around the new upsert helpers.
- `stale`, `IsStale`, `StaleKeys`, `RemoveStaleKeys` remain untouched for backward compatibility.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] New `TestRemoveCommand_Execute_*` covers single-key, by-state (stale, manual), dry-run (both forms), missing-key, no-args, key/state mismatch refusal, no-matches
- [x] New `TestSetCommand_Execute_CreatesNewKey` / `CreatesNewKeyWithState` / `StateIgnoredOnExistingKey` cover the upsert behavior
- [x] New `TestXCStrings_SetTranslation_CreatesWithInitialState` / `DoesNotOverrideExistingState` / `RemoveKey` exercise the model layer
- [x] README updated to document `remove` and the upsert behavior of `set`

Closes #75